### PR TITLE
Add explicit Unix dependency

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -22,7 +22,7 @@ Library ZMQB
                   poll.c,
                   uint64.h,
                   uint64.c
-  BuildDepends:   uint.uint64
+  BuildDepends:   unix, uint.uint64
   CCLib:          -lzmq
   CCOpt:          -Wall -W -Wextra -O2
   CompiledObject: best


### PR DESCRIPTION
lwt-zmq doesn't link properly without this.  It would be nice to have this update in place in opam so I can push out a matching lwt-zmq opam update using this fork of the bindings.
