### PR TITLE
get/set_identity restrictions

### DIFF
--- a/src/ZMQ.mli
+++ b/src/ZMQ.mli
@@ -82,8 +82,8 @@ module Socket : sig
   val get_max_message_size : 'a t -> int
   val set_affinity : 'a t -> int -> unit
   val get_affinity : 'a t -> int
-  val set_identity : [> `Req | `Rep | `Router] t -> string -> unit
-  val get_identity : [> `Req | `Rep | `Router] t -> string
+  val set_identity : 'a t -> string -> unit
+  val get_identity : 'a t -> string
   val subscribe : [> `Sub] t -> string -> unit
   val unsubscribe : [> `Sub] t -> string -> unit
   val get_last_endpoint : 'a t -> string


### PR DESCRIPTION
It seems you should be able to at least set_identity on a `Dealer socket and probably`Sub.

This is done in IPython which won't work without it.

Note also, I changed to 'a rather than my specific requirements of adding `Dealer and`Sub as I could not get the code with these restricted phantom types to actually compile (the function seems to generalize the socket type which I was storing as a [`Dealer] in a record).
