### PR TITLE
Set ZMQ.Socket.t reference to NULL after close

### DIFF
--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -155,6 +155,7 @@ CAMLprim value caml_zmq_close(value socket) {
     CAMLparam1 (socket);
     int result = zmq_close(CAML_ZMQ_Socket_val(socket));
     caml_zmq_raise_if(result == -1, "zmq_close");
+    CAML_ZMQ_Socket_val(socket) = NULL;
     CAMLreturn (Val_unit);
 }
 


### PR DESCRIPTION
zmq_close deallocates the socket, so accessing it would result in a use-after-free.
