### PR TITLE
Change include path to avoid clash on unit64.h

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -21,7 +21,7 @@ Library ZMQ
                   poll.c
   BuildDepends:   unix, uint.uint64
   CCLib:          -lzmq
-  CCOpt:          -I $pkg_uint_uint64 -Wall -Wextra -O2
+  CCOpt:          -I $pkg_uint_uint64/.. -Wall -Wextra -O2
   CompiledObject: best
 
 Flag examples

--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -34,7 +34,7 @@
 #include "context.h"
 #include "socket.h"
 
-#include <uint64.h>
+#include <uint/uint64.h>
 
 /**
  * Version


### PR DESCRIPTION
Including <uint64.h> is too generic and may pick up a file from
Debian's libowfat-dev package instead. This is an attempt to work
around that by including <uint/uint64.h>, which should is not known
to clash with anything.
