### PR TITLE
Compatibility with ZeroMQ 4.1

### DIFF
--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -536,18 +536,14 @@ CAMLprim value caml_decode_monitor_event(value event_val, value addr) {
     CAMLlocal1 (result);
 
     const char *data = String_val(event_val);
-    uint16_t event;
-    int32_t  param;
+    const uint16_t *event = (const uint16_t *)data;
+    const int32_t  *param = (const int32_t *)(data + 2);
 
-    /* Unpack the 6 bytes in "data". */
-    memcpy(&event, data, sizeof(event));
-    memcpy(&param, data + sizeof(event), sizeof(param));
-
-    switch (event) {
+    switch (*event) {
     case ZMQ_EVENT_CONNECTED:
         result = caml_alloc(2, CONNECTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(param));
+        Store_field(result, 1, Val_fd(*param));
         break;
 
     case ZMQ_EVENT_CONNECT_DELAYED:
@@ -558,51 +554,51 @@ CAMLprim value caml_decode_monitor_event(value event_val, value addr) {
     case ZMQ_EVENT_CONNECT_RETRIED:
         result = caml_alloc(2, CONNECT_RETRIED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(param));
+        Store_field(result, 1, Val_int(*param));
         break;
 
     case ZMQ_EVENT_LISTENING:
         result = caml_alloc(2, LISTENING);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(param));
+        Store_field(result, 1, Val_fd(*param));
         break;
 
     case ZMQ_EVENT_BIND_FAILED:
         result = caml_alloc(2, BIND_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(param));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
+        Store_field(result, 1, Val_int(*param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(*param)));
         break;
 
     case ZMQ_EVENT_ACCEPTED:
         result = caml_alloc(2, ACCEPTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(param));
+        Store_field(result, 1, Val_fd(*param));
         break;
 
     case ZMQ_EVENT_ACCEPT_FAILED:
         result = caml_alloc(2, ACCEPT_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(param));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
+        Store_field(result, 1, Val_int(*param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(*param)));
         break;
 
     case ZMQ_EVENT_CLOSED:
         result = caml_alloc(2, CLOSED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(param));
+        Store_field(result, 1, Val_fd(*param));
         break;
 
     case ZMQ_EVENT_CLOSE_FAILED:
         result = caml_alloc(2, CLOSE_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(param));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
+        Store_field(result, 1, Val_int(*param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(*param)));
         break;
     case ZMQ_EVENT_DISCONNECTED:
         result = caml_alloc(2, DISCONNECTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(param));
+        Store_field(result, 1, Val_fd(*param));
         break;
     default:
         caml_invalid_argument("Unknown event type");

--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -536,16 +536,18 @@ CAMLprim value caml_decode_monitor_event(value event_val, value addr) {
     CAMLlocal1 (result);
 
     const char *data = String_val(event_val);
-    zmq_event_t event;
-    /* Dont just map the event structure, as the struct is not packed. */
-    memcpy(&(event.event), data, sizeof(event.event));
-    memcpy(&(event.value), data + sizeof(event.event), sizeof(event.value));
+    uint16_t event;
+    int32_t  param;
 
-    switch (event.event) {
+    /* Unpack the 6 bytes in "data". */
+    memcpy(&event, data, sizeof(event));
+    memcpy(&param, data + sizeof(event), sizeof(param));
+
+    switch (event) {
     case ZMQ_EVENT_CONNECTED:
         result = caml_alloc(2, CONNECTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(event.value));
+        Store_field(result, 1, Val_fd(param));
         break;
 
     case ZMQ_EVENT_CONNECT_DELAYED:
@@ -556,51 +558,51 @@ CAMLprim value caml_decode_monitor_event(value event_val, value addr) {
     case ZMQ_EVENT_CONNECT_RETRIED:
         result = caml_alloc(2, CONNECT_RETRIED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(event.value));
+        Store_field(result, 1, Val_int(param));
         break;
 
     case ZMQ_EVENT_LISTENING:
         result = caml_alloc(2, LISTENING);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(event.value));
+        Store_field(result, 1, Val_fd(param));
         break;
 
     case ZMQ_EVENT_BIND_FAILED:
         result = caml_alloc(2, BIND_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(event.value));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(event.value)));
+        Store_field(result, 1, Val_int(param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
         break;
 
     case ZMQ_EVENT_ACCEPTED:
         result = caml_alloc(2, ACCEPTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(event.value));
+        Store_field(result, 1, Val_fd(param));
         break;
 
     case ZMQ_EVENT_ACCEPT_FAILED:
         result = caml_alloc(2, ACCEPT_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(event.value));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(event.value)));
+        Store_field(result, 1, Val_int(param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
         break;
 
     case ZMQ_EVENT_CLOSED:
         result = caml_alloc(2, CLOSED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(event.value));
+        Store_field(result, 1, Val_fd(param));
         break;
 
     case ZMQ_EVENT_CLOSE_FAILED:
         result = caml_alloc(2, CLOSE_FAILED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_int(event.value));
-        Store_field(result, 2, caml_copy_string(zmq_strerror(event.value)));
+        Store_field(result, 1, Val_int(param));
+        Store_field(result, 2, caml_copy_string(zmq_strerror(param)));
         break;
     case ZMQ_EVENT_DISCONNECTED:
         result = caml_alloc(2, DISCONNECTED);
         Store_field(result, 0, addr);
-        Store_field(result, 1, Val_fd(event.value));
+        Store_field(result, 1, Val_fd(param));
         break;
     default:
         caml_invalid_argument("Unknown event type");


### PR DESCRIPTION
ZeroMQ 4.1 removes the zmq_event_t struct, which was broken anyway.
Our code now declares the individual fields of that struct as local
variables directly.