### PR TITLE
Some flags present in cppzmq but not in zmq are needed in order for o…

### DIFF
--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -36,6 +36,15 @@
 
 #include <uint64.h>
 
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
+#define ZMQ_HAS_PROXY_STEERABLE
+/*  Socket event data  */
+typedef struct {
+    uint16_t event;  // id of the event as bitfield
+    int32_t  value ; // value is either error code, fd or reconnect interval
+} zmq_event_t;
+#endif
+
 /**
  * Version
  */


### PR DESCRIPTION
…caml-zmq to work seemlessly between newer, 4.x+ version of zmq because of event_t struct removal.