### PR TITLE
FreeBSD compatibility

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -20,8 +20,8 @@ Library ZMQ
                   poll.h,
                   poll.c
   BuildDepends:   unix, uint.uint64
-  CCLib:          -lzmq
-  CCOpt:          -I $pkg_uint_uint64 -Wall -Wextra -O2
+  CCLib:          -L/usr/local/lib -lzmq
+  CCOpt:          -I/usr/local/include -I $pkg_uint_uint64 -Wall -Wextra -O2
   CompiledObject: best
 
 Flag examples


### PR DESCRIPTION
Hi,
On FreeBSD, the zmq header file is by default installed in /usr/local/include and the library in /usr/local/lib. This patch is a proposal to add the compatibility with FreeBSD.

A similar patch has also been submitted for the conf-zmq opam package: https://github.com/ocaml/opam-repository/pull/5009