### PR TITLE
Don't include zmq_util.h, it is deprecated

### DIFF
--- a/src/caml_zmq_stubs.c
+++ b/src/caml_zmq_stubs.c
@@ -28,7 +28,6 @@
 #endif
 
 #include <zmq.h>
-#include <zmq_utils.h>
 
 #include "fail.h"
 #include "context.h"


### PR DESCRIPTION
I just happened upon this when building and thought I might as well fix it. It seems to be deprecated since at least 2014, so maybe worth removing it now: https://github.com/zeromq/libzmq/commits/master/include/zmq_utils.h

Not a big problem but it shows a warning when compiling and the file is pretty much empty since functionality has moved into `zmq.h` nowadays.