### PR TITLE
Make the async version compile with async >= v0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TESTS=true
   matrix:
     - OCAML_VERSION=4.03 PACKAGE="zmq"       PINS="zmq:."
+    - OCAML_VERSION=4.03 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
     - OCAML_VERSION=4.04 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.04 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
     - OCAML_VERSION=4.05 PACKAGE="zmq"       PINS="zmq:."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Dependencies
 ------------
 
   * [OPAM](http://opam.ocaml.org/)
-  * OCaml >= 4.03 (>= 4.04.1 if you're async zmq-async)
+  * OCaml >= 4.03
+  * Async >= v0.9.0 for zmq-async
 
 Install
 -------

--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -14,8 +14,8 @@ depends: [
   "jbuilder" {build}
   "configurator" {build}
   "ppx_sexp_conv" {build & >= "v0.9.0"}
-  "base" {>= "v0.10.0"}
-  "async_unix" {>= "v0.10.0"}
-  "async_kernel" {>= "v0.10.0"}
-  "sexplib"
+  "base" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "async_kernel" {>= "v0.9.0"}
+  "sexplib" { >= "v0.9.0" }
 ]

--- a/zmq-async/src/zmq_async.ml
+++ b/zmq-async/src/zmq_async.ml
@@ -1,6 +1,7 @@
 open Base
 open Async_kernel
 open Async_unix
+open Sexplib.Conv
 
 module Socket = struct
   exception Break_event_loop [@@deriving sexp_of]


### PR DESCRIPTION
As far as I can tell, the only difference is the that v0.10.0 automatically includes Sexplib.Conv.sexp_opaque.
But for some reason referencing Sexplib.Conv.sexp_opaque in the structure did not work,
hence the open stmt

