### PR TITLE
zmq-async does not need configurator

### DIFF
--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -12,7 +12,6 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "zmq"
   "jbuilder" {build}
-  "configurator" {build}
   "ppx_sexp_conv" {build & >= "v0.9.0"}
   "base" {>= "v0.9.0"}
   "async_unix" {>= "v0.9.0"}


### PR DESCRIPTION
At least from what I saw it is just a transitive dependency in zmq itself.