### PR TITLE
lwt-zmq import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ env:
   matrix:
     - OCAML_VERSION=4.03 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.03 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+    - OCAML_VERSION=4.03 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
     - OCAML_VERSION=4.04 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.04 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+    - OCAML_VERSION=4.04 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
     - OCAML_VERSION=4.05 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.05 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+    - OCAML_VERSION=4.05 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
     - OCAML_VERSION=4.06 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.06 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+    - OCAML_VERSION=4.06 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dependencies
   * [OPAM](http://opam.ocaml.org/)
   * OCaml >= 4.03
   * Async >= v0.9.0 for zmq-async
+  * Lwt for zmq-lwt
 
 Install
 -------

--- a/zmq-lwt.opam
+++ b/zmq-lwt.opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "Hezekiah M. Carty <hez@0ok.org>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+dev-repo: "git@github.com/issuu/ocaml-zmq.git"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "zmq"
+  "jbuilder" {build}
+  "lwt"
+]

--- a/zmq-lwt/src/jbuild
+++ b/zmq-lwt/src/jbuild
@@ -1,0 +1,6 @@
+(jbuild_version 1)
+
+(library
+ ((name zmq_lwt)
+  (public_name zmq-lwt)
+  (libraries (zmq lwt.unix))))

--- a/zmq-lwt/src/zmq_lwt.ml
+++ b/zmq-lwt/src/zmq_lwt.ml
@@ -1,0 +1,84 @@
+let (>>=) = Lwt.(>>=)
+
+module Socket = struct
+
+  type 'a t = {
+    socket : 'a ZMQ.Socket.t;
+    fd : Lwt_unix.file_descr;
+  }
+
+  exception Break_event_loop
+
+  let of_socket socket = {
+    socket;
+    fd = Lwt_unix.of_unix_file_descr ~blocking:false ~set_flags:false (ZMQ.Socket.get_fd socket);
+  }
+
+  let to_socket s = s.socket
+
+  (* Wrap possible exceptions and events which can occur in a ZeroMQ call *)
+  let wrap f s =
+    let io_loop () =
+      Lwt_unix.wrap_syscall Lwt_unix.Read s.fd (
+        fun () ->
+          try
+            (* Check for zeromq events *)
+            match ZMQ.Socket.events s.socket with
+            | ZMQ.Socket.No_event -> raise Lwt_unix.Retry
+            | ZMQ.Socket.Poll_in
+            | ZMQ.Socket.Poll_out
+            | ZMQ.Socket.Poll_in_out -> f s.socket
+            (* This should not happen as far as I understand *)
+            | ZMQ.Socket.Poll_error -> assert false
+          with
+          (* Not ready *)
+          | Unix.Unix_error (Unix.EAGAIN, _, _) -> raise Lwt_unix.Retry
+          (* We were interrupted so we need to start all over again *)
+          | Unix.Unix_error (Unix.EINTR, _, _) -> raise Break_event_loop
+      )
+    in
+    let rec idle_loop () =
+      Lwt.catch
+        (fun () -> Lwt.wrap1 f s.socket)
+        (function
+          | Unix.Unix_error ( Unix.EAGAIN, _, _) ->
+            Lwt.catch io_loop
+              (function
+                | Break_event_loop -> idle_loop ()
+                | exn -> Lwt.fail exn)
+          | Unix.Unix_error (Unix.EINTR, _, _) ->
+            idle_loop ()
+          | exn -> Lwt.fail exn)
+    in
+    idle_loop ()
+
+  let recv s =
+    wrap (fun s -> ZMQ.Socket.recv ~block:false s) s
+
+  let send ?more s m =
+    wrap (fun s -> ZMQ.Socket.send ?more ~block:false s m) s
+
+  let recv_all s =
+    wrap (fun s -> ZMQ.Socket.recv_all ~block:false s) s
+
+  let send_all s parts =
+    wrap (fun s -> ZMQ.Socket.send_all ~block:false s parts) s
+
+  module Router = struct
+    type id_t = string
+
+    let id_of_string id = id
+
+    let recv s =
+      recv_all s >>= function
+      | id :: message -> Lwt.return (id, message)
+      | _ -> assert false
+
+    let send s id message =
+      send_all s (id :: message)
+  end
+end
+
+module Monitor = struct
+  let recv s = Socket.wrap (fun s -> ZMQ.Monitor.recv ~block:false s) s
+end

--- a/zmq-lwt/src/zmq_lwt.mli
+++ b/zmq-lwt/src/zmq_lwt.mli
@@ -1,0 +1,51 @@
+module Socket : sig
+
+  (** An Lwt-wrapped zeromq socket *)
+  type 'a t
+
+  (** [of_socket s] wraps the zeromq socket [s] for use with Lwt *)
+  val of_socket : 'a ZMQ.Socket.t -> 'a t
+
+  (** [to_socket s] extracts the raw zeromq socket from [s] *)
+  val to_socket : 'a t -> 'a ZMQ.Socket.t
+
+  (** [recv socket] waits for a message on [socket] without blocking other Lwt
+      threads *)
+  val recv : 'a t -> string Lwt.t
+
+  (** [send ?more socket m] sends a message [m] on [socket] without blocking other
+      Lwt threads *)
+  val send : ?more:bool -> 'a t -> string -> unit Lwt.t
+
+  (** [recv_all socket] waits for a multi-part message on [socket] without
+      blocking other Lwt threads *)
+  val recv_all : 'a t -> string list Lwt.t
+
+  (** [send_all socket m] sends all parts of the multi-part message [m] on
+      [socket] without blocking other Lwt threads *)
+  val send_all : 'a t -> string list -> unit Lwt.t
+
+  module Router : sig
+
+    (** Identity of a socket connected to the router. *)
+    type id_t = private string
+
+    (** [id_of_string s] coerces [s] into an {!id_t}. *)
+    val id_of_string : string -> id_t
+
+    (** [recv socket] waits for a message on [socket] without blocking other Lwt
+        threads. *)
+    val recv : [ `Router ] t -> (id_t * string list) Lwt.t
+
+    (** [send socket id message] sends [message] on [socket] to [id] without
+        blocking other Lwt threads. *)
+    val send : [ `Router ] t -> id_t -> string list -> unit Lwt.t
+  end
+end
+
+module Monitor : sig
+
+  (** [recv socket] waits for a monitoring event on [socket] without blocking other
+      Lwt threads. *)
+  val recv : [ `Monitor ] Socket.t -> ZMQ.Monitor.event Lwt.t
+end


### PR DESCRIPTION
This is a direct import of lwt-zmq with a module rename to match the async import and a separate commit moving exception handling from `try` to `match`.

Related to #54 and #56 