### PR TITLE
Add REPL/utop and Github pages targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,19 @@ examples:
 
 # requires odoc
 doc:
-	jbuilder build @odoc
+	jbuilder build @doc
 
 test:
 	jbuilder runtest
+
+repl:
+	jbuilder utop zmq/src
+
+repl-lwt:
+	jbuilder utop zmq-lwt/src
+
+repl-async:
+	jbuilder utop zmq-async/src
 
 all:
 	jbuilder build @install @examples
@@ -24,4 +33,16 @@ uninstall:
 clean:
 	jbuilder clean
 
-.PHONY: build doc test all install uninstall clean configure examples
+gh-pages: doc
+	git clone `git config --get remote.origin.url` .gh-pages --reference .
+	git -C .gh-pages checkout --orphan gh-pages
+	git -C .gh-pages reset
+	git -C .gh-pages clean -dxf
+	cp  -r _build/default/_doc/* .gh-pages
+	git -C .gh-pages add .
+	git -C .gh-pages config user.email 'docs@ocaml-zmq'
+	git -C .gh-pages commit -m "Update Pages"
+	git -C .gh-pages push origin gh-pages -f
+	rm -rf .gh-pages
+
+.PHONY: build doc test all install uninstall clean configure examples repl repl-lwt repl-async gh-pages


### PR DESCRIPTION
Also fix a typo in the `make doc` target.

Additions:
* `make repl` will start a utop instance with `ZMQ` compiled and available
* `make repl-async` will start a utop instance with `ZMQ` and `Zmq_async` compiled and available
* `make repl-lwt` will start a utop instance with `ZMQ` and `Zmq_lwt` compiled and available
* `make gh-pages` will build the documentation then push the results to the project's `github.io` page

I've tested the REPL targets but not the gh-pages target.  I have tested the same `gh-pages` target on other projects though.