### PR TITLE
Add Ivar for faster signalling to waiting processes. 

### DIFF
--- a/zmq-async/src/deferred.ml
+++ b/zmq-async/src/deferred.ml
@@ -23,6 +23,8 @@ module Condition = struct
   let signal t v = Condition.signal t v
 end
 
+module Ivar = Async_kernel.Ivar
+
 module Fd = struct
   type 'a t' = 'a t
   type t = Fd.t

--- a/zmq-async/src/deferred.ml
+++ b/zmq-async/src/deferred.ml
@@ -23,7 +23,13 @@ module Condition = struct
   let signal t v = Condition.signal t v
 end
 
-module Ivar = Async_kernel.Ivar
+module Mailbox = struct
+  type 'a t = 'a Async_kernel.Ivar.t
+  let create () = Async_kernel.Ivar.create ()
+  let send t v = Async_kernel.Ivar.fill t v
+  let recv t = Async_kernel.Ivar.read t
+end
+
 
 module Fd = struct
   type 'a t' = 'a t

--- a/zmq-deferred/src/deferred.ml
+++ b/zmq-deferred/src/deferred.ml
@@ -20,6 +20,13 @@ module type T = sig
     val signal: 'a t -> 'a -> unit
   end
 
+  module Ivar : sig
+    type 'a t
+    val create: unit -> 'a t
+    val fill: 'a t -> 'a -> unit
+    val read: 'a t -> 'a Deferred.t
+  end
+
   module Fd : sig
     type t
     (* Wrap the given unix file_deser *)

--- a/zmq-deferred/src/deferred.ml
+++ b/zmq-deferred/src/deferred.ml
@@ -20,11 +20,11 @@ module type T = sig
     val signal: 'a t -> 'a -> unit
   end
 
-  module Ivar : sig
+  module Mailbox : sig
     type 'a t
     val create: unit -> 'a t
-    val fill: 'a t -> 'a -> unit
-    val read: 'a t -> 'a Deferred.t
+    val send: 'a t -> 'a -> unit
+    val recv: 'a t -> 'a Deferred.t
   end
 
   module Fd : sig

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -100,7 +100,7 @@ module Make(T: Deferred.T) = struct
 
   type op = Send | Receive
   let post: _ t -> op -> (_ ZMQ.Socket.t -> 'a) -> 'a Deferred.t = fun t op f ->
-    let f' cond () =
+    let f' ivar () =
       let res = match f t.socket with
         | v -> Ok v
         | exception Unix.Unix_error (Unix.EAGAIN, _, _) ->
@@ -108,15 +108,15 @@ module Make(T: Deferred.T) = struct
           raise Retry
         | exception exn -> Error exn
       in
-      Condition.signal cond res
+      Ivar.fill ivar res
     in
     let queue = match op with
       | Send -> t.senders
       | Receive -> t.receivers
     in
-    let cond = Condition.create () in
+    let ivar = Ivar.create () in
     let should_signal = Queue.is_empty queue in
-    Queue.push (f' cond) queue;
+    Queue.push (f' ivar) queue;
 
     (* Wakeup the thread if the queue was empty *)
     begin
@@ -125,7 +125,7 @@ module Make(T: Deferred.T) = struct
       | false -> ()
     end;
 
-    Condition.wait cond >>= function
+    Ivar.read ivar >>= function
     | Ok v -> Deferred.return v
     | Error exn -> Deferred.fail exn
 

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -100,7 +100,7 @@ module Make(T: Deferred.T) = struct
 
   type op = Send | Receive
   let post: _ t -> op -> (_ ZMQ.Socket.t -> 'a) -> 'a Deferred.t = fun t op f ->
-    let f' ivar () =
+    let f' mailbox () =
       let res = match f t.socket with
         | v -> Ok v
         | exception Unix.Unix_error (Unix.EAGAIN, _, _) ->
@@ -108,15 +108,15 @@ module Make(T: Deferred.T) = struct
           raise Retry
         | exception exn -> Error exn
       in
-      Mailbox.send ivar res
+      Mailbox.send mailbox res
     in
     let queue = match op with
       | Send -> t.senders
       | Receive -> t.receivers
     in
-    let ivar = Mailbox.create () in
+    let mailbox = Mailbox.create () in
     let should_signal = Queue.is_empty queue in
-    Queue.push (f' ivar) queue;
+    Queue.push (f' mailbox) queue;
 
     (* Wakeup the thread if the queue was empty *)
     begin
@@ -125,7 +125,7 @@ module Make(T: Deferred.T) = struct
       | false -> ()
     end;
 
-    Mailbox.recv ivar >>= function
+    Mailbox.recv mailbox >>= function
     | Ok v -> Deferred.return v
     | Error exn -> Deferred.fail exn
 

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -108,13 +108,13 @@ module Make(T: Deferred.T) = struct
           raise Retry
         | exception exn -> Error exn
       in
-      Ivar.fill ivar res
+      Mailbox.send ivar res
     in
     let queue = match op with
       | Send -> t.senders
       | Receive -> t.receivers
     in
-    let ivar = Ivar.create () in
+    let ivar = Mailbox.create () in
     let should_signal = Queue.is_empty queue in
     Queue.push (f' ivar) queue;
 
@@ -125,7 +125,7 @@ module Make(T: Deferred.T) = struct
       | false -> ()
     end;
 
-    Ivar.read ivar >>= function
+    Mailbox.recv ivar >>= function
     | Ok v -> Deferred.return v
     | Error exn -> Deferred.fail exn
 

--- a/zmq-lwt/src/deferred.ml
+++ b/zmq-lwt/src/deferred.ml
@@ -20,11 +20,11 @@ module Condition = struct
   let signal t v = Lwt_condition.signal t v
 end
 
-module Ivar = struct
+module Mailbox = struct
   type 'a t = ('a Lwt.t * 'a Lwt.u)
   let create () = Lwt.wait ()
-  let fill (_, u) v = Lwt.wakeup_later u v
-  let read (t, _) = t
+  let send (_, u) v = Lwt.wakeup_later u v
+  let recv (t, _) = t
 end
 
 module Fd = struct

--- a/zmq-lwt/src/deferred.ml
+++ b/zmq-lwt/src/deferred.ml
@@ -20,6 +20,13 @@ module Condition = struct
   let signal t v = Lwt_condition.signal t v
 end
 
+module Ivar = struct
+  type 'a t = ('a Lwt.t * 'a Lwt.u)
+  let create () = Lwt.wait ()
+  let fill (_, u) v = Lwt.wakeup_later u v
+  let read (t, _) = t
+end
+
 module Fd = struct
   type t = Lwt_unix.file_descr
 


### PR DESCRIPTION
Use Lwt.wait / Async.Ivar for single waiter signalling, rather than a condition variable.

Gives a slight speedup for async and a detectable speedup for lwt. 
(Note that my test machine is an old laptop - results may vary)
```
          This branch       master        This branch    master                                               
             Async:       Async(m):        Lwt:         Lwt(m):
real	     0m3.465s     0m3.477s         0m4.052s     0m4.470s
user	     0m2.049s     0m2.109s         0m2.438s     0m2.723s
sys	     0m1.334s     0m1.224s         0m0.924s     0m0.960s
```


