### PR TITLE
Rename ZMQ.Msg.data to ZMQ.Msg.bigstring

### DIFF
--- a/zmq/src/ZMQ.ml
+++ b/zmq/src/ZMQ.ml
@@ -53,9 +53,9 @@ module Msg = struct
   open Bigarray
 
   type t
-  type data = (char, int8_unsigned_elt, c_layout) Array1.t
+  type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
 
-  external native_init_data : data -> int -> int -> t =
+  external native_init_data : bigstring -> int -> int -> t =
     "caml_zmq_msg_init_data"
 
   let init_data ?(offset = 0) ?length buf =
@@ -69,7 +69,7 @@ module Msg = struct
 
   external size : t -> int = "caml_zmq_msg_size"
 
-  external unsafe_data : t -> data = "caml_zmq_msg_data"
+  external unsafe_data : t -> bigstring = "caml_zmq_msg_data"
 
   let copy_data msg =
     let data = unsafe_data msg in

--- a/zmq/src/ZMQ.mli
+++ b/zmq/src/ZMQ.mli
@@ -29,7 +29,7 @@ end
 module Msg : sig
   type t
 
-  type data =
+  type bigstring =
     (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
   (** Initialize a new message with the given data.  The data will be
@@ -40,20 +40,20 @@ module Msg : sig
       @param length specifies the number of bytes, starting from [offset],
              to use.  Defaults the [length of data - offset].
   *)
-  val init_data : ?offset:int -> ?length:int -> data -> t
+  val init_data : ?offset:int -> ?length:int -> bigstring -> t
 
   (** Size of the message in bytes *)
   val size : t -> int
 
   (** Retrieve a copy of the data contained in the message. *)
-  val copy_data : t -> data
+  val copy_data : t -> bigstring
 
   (** Retrieve the data contained in the message.
 
       This is considered {b unsafe} because the underly data may be freed
       when the message's lifetime expires.
   *)
-  val unsafe_data : t -> data
+  val unsafe_data : t -> bigstring
 
   (** Free the message.  This will be done automatically when the message
       is garbage collected.


### PR DESCRIPTION
This type is common in the OCaml ecosystem.  There's no need to deviate
from the common naming convention for this type.