### PR TITLE
Execute tests always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-# add --dev flag here when warnings are fixed
 build:
 	jbuilder build @install @examples --dev
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ doc:
 	jbuilder build @doc
 
 test:
-	jbuilder runtest --dev
+	jbuilder runtest --dev --force
 
 repl:
 	jbuilder utop zmq/src

--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -12,7 +12,7 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "zmq"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta17"}
   "async_unix" {>= "v0.9.0"}
   "async_kernel" {>= "v0.9.0"}
   "base" {>= "v0.9.0"}

--- a/zmq-lwt.opam
+++ b/zmq-lwt.opam
@@ -12,6 +12,6 @@ build: [
 build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 depends: [
   "zmq"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta17"}
   "lwt"
 ]

--- a/zmq.opam
+++ b/zmq.opam
@@ -12,7 +12,7 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "conf-zmq"
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta17"}
   "configurator" {build}
   "ounit" {test}
   "base-unix"


### PR DESCRIPTION
jbuilder has a habit of running tests only once when they have succeeded once, a subsequent run will just succeed without running the tests again.

I think it is useful to be able to run the tests multiple times, of only to see whether the tests are flaky.

jbuilder learned the `--force` flag in `1.0+beta17`