### PR TITLE
Use dune.configurator rather than standalone configurator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 * Update build config to use new dune syntax
 
+* Remove configurator in favor of dune.configurator. This removes the build time
+  dependency on the configurator and base packages.
+
 5.0.0
 -----
 

--- a/zmq-lwt/src/dune
+++ b/zmq-lwt/src/dune
@@ -1,4 +1,4 @@
 (library
  (name zmq_lwt)
  (public_name zmq-lwt)
- (libraries zmq.deferred lwt lwt.unix base))
+ (libraries zmq.deferred lwt lwt.unix))

--- a/zmq.opam
+++ b/zmq.opam
@@ -13,7 +13,6 @@ build-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
   "conf-zmq"
   "dune" {build}
-  "configurator" {build}
   "ounit" {test}
   "base-unix"
   "stdint" { >= "0.4.2" }

--- a/zmq/src/config/discover.ml
+++ b/zmq/src/config/discover.ml
@@ -1,21 +1,19 @@
-open Base
-open Stdio
+module C = Configurator.V1
 
 let () =
-  let module C = Configurator in
   C.main ~name:"zmq" (fun c ->
-    let default : C.Pkg_config.package_conf = {
-      libs = ["-lzmq"];
-      cflags = []
-    } in
-    let conf =
-      match C.Pkg_config.get c with
-      | None -> default
-      | Some pc ->
-          Option.value (C.Pkg_config.query pc ~package:"libzmq") ~default
-    in
-    let write_sexp file sexp =
-      Out_channel.write_all file ~data:(Sexp.to_string sexp)
-    in
-    write_sexp "c_flags.sexp" (sexp_of_list sexp_of_string conf.cflags);
-    write_sexp "c_library_flags.sexp" (sexp_of_list sexp_of_string conf.libs))
+      let default : C.Pkg_config.package_conf = {
+        libs = ["-lzmq"];
+        cflags = []
+      } in
+      let conf =
+        match C.Pkg_config.get c with
+        | None -> default
+        | Some pc ->
+          begin match C.Pkg_config.query pc ~package:"libzmq" with
+            | Some s -> s
+            | None -> default
+          end
+      in
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/zmq/src/config/dune
+++ b/zmq/src/config/dune
@@ -1,3 +1,3 @@
 (executable
   (name discover)
-  (libraries base stdio configurator))
+  (libraries dune.configurator))

--- a/zmq/src/dune
+++ b/zmq/src/dune
@@ -10,4 +10,4 @@
 (rule
   (targets c_flags.sexp c_library_flags.sexp)
   (deps (:discover config/discover.exe))
-  (action (run %{discover} -ocamlc %{ocamlc})))
+  (action (run %{discover})))


### PR DESCRIPTION
This shaves off a build dependencies and simplifies the configuration script.

Given that we've switched to dune, we might as well go all the way.