### PR TITLE
Add support for 4.08

### DIFF
--- a/zmq/src/context.c
+++ b/zmq/src/context.c
@@ -25,6 +25,9 @@ static struct custom_operations caml_zmq_context_ops = {
 #ifdef custom_compare_ext_default
     , custom_compare_ext_default
 #endif
+#ifdef custom_fixed_length_default
+    , custom_fixed_length_default
+#endif
 };
 
 value caml_zmq_copy_context(void *zmq_context) {

--- a/zmq/src/msg.c
+++ b/zmq/src/msg.c
@@ -27,6 +27,9 @@ static struct custom_operations caml_zmq_msg_ops = {
 #ifdef custom_compare_ext_default
     , custom_compare_ext_default
 #endif
+#ifdef custom_fixed_length_default
+    , custom_fixed_length_default
+#endif
 };
 
 value caml_zmq_copy_msg(void *zmq_msg) {
@@ -36,4 +39,3 @@ value caml_zmq_copy_msg(void *zmq_msg) {
     CAML_ZMQ_Msg_val(msg) = zmq_msg;
     CAMLreturn (msg);
 }
-

--- a/zmq/src/poll.c
+++ b/zmq/src/poll.c
@@ -26,6 +26,9 @@ static struct custom_operations caml_zmq_poll_ops = {
 #ifdef custom_compare_ext_default
     , custom_compare_ext_default
 #endif
+#ifdef custom_fixed_length_default
+    , custom_fixed_length_default
+#endif
 };
 
 CAMLprim value caml_zmq_poll_of_pollitem_array(value pollitem_array) {

--- a/zmq/src/socket.c
+++ b/zmq/src/socket.c
@@ -26,6 +26,9 @@ static struct custom_operations caml_zmq_socket_ops = {
 #ifdef custom_compare_ext_default
     , custom_compare_ext_default
 #endif
+#ifdef custom_fixed_length_default
+    , custom_fixed_length_default
+#endif
 };
 
 /* Captures a reference to the context to avoid collecting it prematurely */


### PR DESCRIPTION
The upcoming OCaml 4.08 introduces a new field in
custom blocks, namely custom_fixed_length_default.

This pull request uses conditional compilation to
support both 4.07 and 4.08.