### PR TITLE
Fix get_curve_{publickey,secretkey,serverkey}

### DIFF
--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -595,6 +595,15 @@ CAMLprim value caml_zmq_msg_close(value msg) {
     CAMLreturn(Val_unit);
 }
 
+CAMLprim value caml_zmq_msg_gets(value msg, value property) {
+    CAMLparam2(msg, property);
+    CAMLlocal1(result);
+    const char *r = zmq_msg_gets(CAML_ZMQ_Msg_val(msg), String_val(property));
+    caml_zmq_raise_if(!r, "zmq_msg_gets");
+    result = caml_copy_string(r);
+    CAMLreturn(result);
+}
+
 
 /**
  * Devices

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <assert.h>
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
@@ -301,10 +302,11 @@ CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
     CAMLreturn (caml_copy_int64(mark));
 }
 
-CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name) {
-    CAMLparam2 (socket, option_name);
+CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value option_maxlen) {
+    CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
-    size_t buffer_size = sizeof (buffer) - 1;
+    size_t buffer_size = 1 + Unsigned_long_val(option_maxlen);
+    assert(buffer_size < sizeof (buffer));
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
                                  native_bytes_option_for[Int_val(option_name)],
                                  buffer,

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -78,6 +78,8 @@ module Msg = struct
     copy
 
   external close : t -> unit = "caml_zmq_msg_close"
+
+  external gets : t -> string -> string = "caml_zmq_msg_gets"
 end
 
 module Socket = struct

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -164,7 +164,7 @@ module Socket = struct
     'a t -> bytes_option -> string -> unit = "caml_zmq_set_bytes_option"
 
   external get_bytes_option :
-    'a t -> bytes_option -> string = "caml_zmq_get_bytes_option"
+    'a t -> bytes_option -> int -> string = "caml_zmq_get_bytes_option"
 
   [@@@warning "-37"]
   type int_option =
@@ -231,7 +231,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_IDENTITY identity
 
   let get_identity socket =
-    get_bytes_option socket ZMQ_IDENTITY
+    get_bytes_option socket ZMQ_IDENTITY 255
 
   let subscribe socket topic =
     set_bytes_option socket ZMQ_SUBSCRIBE topic
@@ -240,7 +240,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_UNSUBSCRIBE topic
 
   let get_last_endpoint socket =
-    get_bytes_option socket ZMQ_LAST_ENDPOINT
+    get_bytes_option socket ZMQ_LAST_ENDPOINT 255
 
   let set_tcp_accept_filter socket filter =
     set_bytes_option socket ZMQ_TCP_ACCEPT_FILTER filter
@@ -438,13 +438,13 @@ module Socket = struct
     set_bytes_option socket ZMQ_PLAIN_USERNAME
 
   let get_plain_username socket =
-    get_bytes_option socket ZMQ_PLAIN_USERNAME
+    get_bytes_option socket ZMQ_PLAIN_USERNAME 255
 
   let set_plain_password socket =
     set_bytes_option socket ZMQ_PLAIN_PASSWORD
 
   let get_plain_password socket =
-    get_bytes_option socket ZMQ_PLAIN_PASSWORD
+    get_bytes_option socket ZMQ_PLAIN_PASSWORD 255
 
   let validate_curve_key_length str msg =
     match String.length str with
@@ -452,21 +452,21 @@ module Socket = struct
     | _ -> invalid_arg msg
 
   let get_curve_publickey socket =
-    get_bytes_option socket ZMQ_CURVE_PUBLICKEY
+    get_bytes_option socket ZMQ_CURVE_PUBLICKEY 40
 
   let set_curve_publickey socket str =
     validate_curve_key_length str "set_curve_publickey";
     set_bytes_option socket ZMQ_CURVE_PUBLICKEY str
 
   let get_curve_secretkey socket =
-    get_bytes_option socket ZMQ_CURVE_SECRETKEY
+    get_bytes_option socket ZMQ_CURVE_SECRETKEY 40
 
   let set_curve_secretkey socket str =
     validate_curve_key_length str "set_curve_secretkey";
     set_bytes_option socket ZMQ_CURVE_SECRETKEY str
 
   let get_curve_serverkey socket =
-    get_bytes_option socket ZMQ_CURVE_SERVERKEY
+    get_bytes_option socket ZMQ_CURVE_SERVERKEY 40
 
   let set_curve_serverkey socket str =
     validate_curve_key_length str "set_curve_serverkey";
@@ -483,7 +483,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_ZAP_DOMAIN
 
   let get_zap_domain socket =
-    get_bytes_option socket ZMQ_ZAP_DOMAIN
+    get_bytes_option socket ZMQ_ZAP_DOMAIN 255
 
   let set_conflate socket flag =
     set_int_option socket ZMQ_CONFLATE (if flag then 1 else 0)

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -59,6 +59,12 @@ module Msg : sig
       is garbage collected.
   *)
   val close : t -> unit
+
+  (** Retrieve a property attached to a message. Property are simple strings.
+      Example of properties include: "Socket-Type", "Identity", "Resource",
+      but underlying transport and security mechanism may add more.
+  *)
+  val gets : t -> string -> string
 end
 
 module Socket : sig


### PR DESCRIPTION
For those, the size of the buffer passed to getsockopt is significant
and must be either 32 (to receive key as binary) or 41 (to receive
key as z85).

The patch merely sets the buffer size to 41 for those options, so that
the caller is returned the keys in z85 format.

Previously, calling those functions would result in an error with
errno set to EINVAL.

Closes #85