### PR TITLE
Fix get_curve_{publickey,secretkey,serverkey} (rebased)

### DIFF
--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -309,7 +309,7 @@ CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value 
     CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
     size_t buffer_size = Unsigned_long_val(option_maxlen);
-    assert(buffer_size <= sizeof (buffer));
+    assert(buffer_size < sizeof (buffer));
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
                                  native_bytes_option_for[Int_val(option_name)],
                                  buffer,

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -309,7 +309,7 @@ CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value 
     CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
     size_t buffer_size = 1 + Unsigned_long_val(option_maxlen);
-    assert(buffer_size < sizeof (buffer));
+    assert(buffer_size <= sizeof (buffer));
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
                                  native_bytes_option_for[Int_val(option_name)],
                                  buffer,

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -308,7 +308,7 @@ CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
 CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value option_maxlen) {
     CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
-    size_t buffer_size = 1 + Unsigned_long_val(option_maxlen);
+    size_t buffer_size = Unsigned_long_val(option_maxlen);
     assert(buffer_size <= sizeof (buffer));
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
                                  native_bytes_option_for[Int_val(option_name)],

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <assert.h>
 
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
@@ -304,10 +305,11 @@ CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
     CAMLreturn (caml_copy_int64(mark));
 }
 
-CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name) {
-    CAMLparam2 (socket, option_name);
+CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value option_maxlen) {
+    CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
-    size_t buffer_size = sizeof (buffer) - 1;
+    size_t buffer_size = 1 + Unsigned_long_val(option_maxlen);
+    assert(buffer_size < sizeof (buffer));
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
                                  native_bytes_option_for[Int_val(option_name)],
                                  buffer,

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -216,7 +216,7 @@ static int const native_bytes_option_for[] = {
     ZMQ_ZAP_DOMAIN,
 };
 
-int caml_zmq_set_bytes_option(value socket, value option_name, value socket_option) {
+int caml_zmq_set_string_option(value socket, value option_name, value socket_option) {
     CAMLparam3 (socket, option_name, socket_option);
 
     char *option_value = String_val(socket_option);
@@ -305,7 +305,7 @@ CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
     CAMLreturn (caml_copy_int64(mark));
 }
 
-CAMLprim value caml_zmq_get_bytes_option(value socket, value option_name, value option_maxlen) {
+CAMLprim value caml_zmq_get_string_option(value socket, value option_name, value option_maxlen) {
     CAMLparam3 (socket, option_name, option_maxlen);
     char buffer[256];
     size_t buffer_size = Unsigned_long_val(option_maxlen);

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -166,7 +166,7 @@ module Socket = struct
     'a t -> bytes_option -> string -> unit = "caml_zmq_set_bytes_option"
 
   external get_bytes_option :
-    'a t -> bytes_option -> string = "caml_zmq_get_bytes_option"
+    'a t -> bytes_option -> int -> string = "caml_zmq_get_bytes_option"
 
   [@@@warning "-37"]
   type int_option =
@@ -233,7 +233,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_IDENTITY identity
 
   let get_identity socket =
-    get_bytes_option socket ZMQ_IDENTITY
+    get_bytes_option socket ZMQ_IDENTITY 255
 
   let subscribe socket topic =
     set_bytes_option socket ZMQ_SUBSCRIBE topic
@@ -242,7 +242,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_UNSUBSCRIBE topic
 
   let get_last_endpoint socket =
-    get_bytes_option socket ZMQ_LAST_ENDPOINT
+    get_bytes_option socket ZMQ_LAST_ENDPOINT 255
 
   let set_tcp_accept_filter socket filter =
     set_bytes_option socket ZMQ_TCP_ACCEPT_FILTER filter
@@ -440,13 +440,13 @@ module Socket = struct
     set_bytes_option socket ZMQ_PLAIN_USERNAME
 
   let get_plain_username socket =
-    get_bytes_option socket ZMQ_PLAIN_USERNAME
+    get_bytes_option socket ZMQ_PLAIN_USERNAME 255
 
   let set_plain_password socket =
     set_bytes_option socket ZMQ_PLAIN_PASSWORD
 
   let get_plain_password socket =
-    get_bytes_option socket ZMQ_PLAIN_PASSWORD
+    get_bytes_option socket ZMQ_PLAIN_PASSWORD 255
 
   let validate_curve_key_length str msg =
     match String.length str with
@@ -454,21 +454,21 @@ module Socket = struct
     | _ -> invalid_arg msg
 
   let get_curve_publickey socket =
-    get_bytes_option socket ZMQ_CURVE_PUBLICKEY
+    get_bytes_option socket ZMQ_CURVE_PUBLICKEY 40
 
   let set_curve_publickey socket str =
     validate_curve_key_length str "set_curve_publickey";
     set_bytes_option socket ZMQ_CURVE_PUBLICKEY str
 
   let get_curve_secretkey socket =
-    get_bytes_option socket ZMQ_CURVE_SECRETKEY
+    get_bytes_option socket ZMQ_CURVE_SECRETKEY 40
 
   let set_curve_secretkey socket str =
     validate_curve_key_length str "set_curve_secretkey";
     set_bytes_option socket ZMQ_CURVE_SECRETKEY str
 
   let get_curve_serverkey socket =
-    get_bytes_option socket ZMQ_CURVE_SERVERKEY
+    get_bytes_option socket ZMQ_CURVE_SERVERKEY 40
 
   let set_curve_serverkey socket str =
     validate_curve_key_length str "set_curve_serverkey";
@@ -485,7 +485,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_ZAP_DOMAIN
 
   let get_zap_domain socket =
-    get_bytes_option socket ZMQ_ZAP_DOMAIN
+    get_bytes_option socket ZMQ_ZAP_DOMAIN 255
 
   let set_conflate socket flag =
     set_int_option socket ZMQ_CONFLATE (if flag then 1 else 0)

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -232,8 +232,11 @@ module Socket = struct
     validate_string_length 1 255 identity "set_identity";
     set_bytes_option socket ZMQ_IDENTITY identity
 
+  let maximal_buffer_length = 255
+  let curve_z85_buffer_length = 40
+
   let get_identity socket =
-    get_bytes_option socket ZMQ_IDENTITY 255
+    get_bytes_option socket ZMQ_IDENTITY maximal_buffer_length
 
   let subscribe socket topic =
     set_bytes_option socket ZMQ_SUBSCRIBE topic
@@ -242,7 +245,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_UNSUBSCRIBE topic
 
   let get_last_endpoint socket =
-    get_bytes_option socket ZMQ_LAST_ENDPOINT 255
+    get_bytes_option socket ZMQ_LAST_ENDPOINT maximal_buffer_length
 
   let set_tcp_accept_filter socket filter =
     set_bytes_option socket ZMQ_TCP_ACCEPT_FILTER filter
@@ -440,13 +443,13 @@ module Socket = struct
     set_bytes_option socket ZMQ_PLAIN_USERNAME
 
   let get_plain_username socket =
-    get_bytes_option socket ZMQ_PLAIN_USERNAME 255
+    get_bytes_option socket ZMQ_PLAIN_USERNAME maximal_buffer_length
 
   let set_plain_password socket =
     set_bytes_option socket ZMQ_PLAIN_PASSWORD
 
   let get_plain_password socket =
-    get_bytes_option socket ZMQ_PLAIN_PASSWORD 255
+    get_bytes_option socket ZMQ_PLAIN_PASSWORD maximal_buffer_length
 
   let validate_curve_key_length str msg =
     match String.length str with
@@ -454,21 +457,21 @@ module Socket = struct
     | _ -> invalid_arg msg
 
   let get_curve_publickey socket =
-    get_bytes_option socket ZMQ_CURVE_PUBLICKEY 40
+    get_bytes_option socket ZMQ_CURVE_PUBLICKEY curve_z85_buffer_length
 
   let set_curve_publickey socket str =
     validate_curve_key_length str "set_curve_publickey";
     set_bytes_option socket ZMQ_CURVE_PUBLICKEY str
 
   let get_curve_secretkey socket =
-    get_bytes_option socket ZMQ_CURVE_SECRETKEY 40
+    get_bytes_option socket ZMQ_CURVE_SECRETKEY curve_z85_buffer_length
 
   let set_curve_secretkey socket str =
     validate_curve_key_length str "set_curve_secretkey";
     set_bytes_option socket ZMQ_CURVE_SECRETKEY str
 
   let get_curve_serverkey socket =
-    get_bytes_option socket ZMQ_CURVE_SERVERKEY 40
+    get_bytes_option socket ZMQ_CURVE_SERVERKEY curve_z85_buffer_length
 
   let set_curve_serverkey socket str =
     validate_curve_key_length str "set_curve_serverkey";
@@ -485,7 +488,7 @@ module Socket = struct
     set_bytes_option socket ZMQ_ZAP_DOMAIN
 
   let get_zap_domain socket =
-    get_bytes_option socket ZMQ_ZAP_DOMAIN 255
+    get_bytes_option socket ZMQ_ZAP_DOMAIN maximal_buffer_length
 
   let set_conflate socket flag =
     set_int_option socket ZMQ_CONFLATE (if flag then 1 else 0)

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -232,8 +232,8 @@ module Socket = struct
     validate_string_length 1 255 identity "set_identity";
     set_bytes_option socket ZMQ_IDENTITY identity
 
-  let maximal_buffer_length = 255
-  let curve_z85_buffer_length = 40
+  let maximal_buffer_length = 256
+  let curve_z85_buffer_length = 41
 
   let get_identity socket =
     get_bytes_option socket ZMQ_IDENTITY maximal_buffer_length

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -232,7 +232,7 @@ module Socket = struct
     validate_string_length 1 255 identity "set_identity";
     set_bytes_option socket ZMQ_IDENTITY identity
 
-  let maximal_buffer_length = 256
+  let maximal_buffer_length = 255
   let curve_z85_buffer_length = 41
 
   let get_identity socket =

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -149,7 +149,7 @@ module Socket = struct
     'a t -> uint64_option -> Uint64.t = "caml_zmq_get_uint64_option"
 
 
-  type bytes_option =
+  type string_option =
   | ZMQ_IDENTITY
   | ZMQ_SUBSCRIBE
   | ZMQ_UNSUBSCRIBE
@@ -162,11 +162,11 @@ module Socket = struct
   | ZMQ_CURVE_SERVERKEY
   | ZMQ_ZAP_DOMAIN
 
-  external set_bytes_option :
-    'a t -> bytes_option -> string -> unit = "caml_zmq_set_bytes_option"
+  external set_string_option :
+    'a t -> string_option -> string -> unit = "caml_zmq_set_string_option"
 
-  external get_bytes_option :
-    'a t -> bytes_option -> int -> string = "caml_zmq_get_bytes_option"
+  external get_string_option :
+    'a t -> string_option -> int -> string = "caml_zmq_get_string_option"
 
   [@@@warning "-37"]
   type int_option =
@@ -230,25 +230,25 @@ module Socket = struct
 
   let set_identity socket identity =
     validate_string_length 1 255 identity "set_identity";
-    set_bytes_option socket ZMQ_IDENTITY identity
+    set_string_option socket ZMQ_IDENTITY identity
 
   let maximal_buffer_length = 255
   let curve_z85_buffer_length = 41
 
   let get_identity socket =
-    get_bytes_option socket ZMQ_IDENTITY maximal_buffer_length
+    get_string_option socket ZMQ_IDENTITY maximal_buffer_length
 
   let subscribe socket topic =
-    set_bytes_option socket ZMQ_SUBSCRIBE topic
+    set_string_option socket ZMQ_SUBSCRIBE topic
 
   let unsubscribe socket topic =
-    set_bytes_option socket ZMQ_UNSUBSCRIBE topic
+    set_string_option socket ZMQ_UNSUBSCRIBE topic
 
   let get_last_endpoint socket =
-    get_bytes_option socket ZMQ_LAST_ENDPOINT maximal_buffer_length
+    get_string_option socket ZMQ_LAST_ENDPOINT maximal_buffer_length
 
   let set_tcp_accept_filter socket filter =
-    set_bytes_option socket ZMQ_TCP_ACCEPT_FILTER filter
+    set_string_option socket ZMQ_TCP_ACCEPT_FILTER filter
 
   let set_rate socket rate =
     set_int_option socket ZMQ_RATE rate
@@ -440,16 +440,16 @@ module Socket = struct
     set_int_option socket ZMQ_CURVE_SERVER (if flag then 1 else 0)
 
   let set_plain_username socket =
-    set_bytes_option socket ZMQ_PLAIN_USERNAME
+    set_string_option socket ZMQ_PLAIN_USERNAME
 
   let get_plain_username socket =
-    get_bytes_option socket ZMQ_PLAIN_USERNAME maximal_buffer_length
+    get_string_option socket ZMQ_PLAIN_USERNAME maximal_buffer_length
 
   let set_plain_password socket =
-    set_bytes_option socket ZMQ_PLAIN_PASSWORD
+    set_string_option socket ZMQ_PLAIN_PASSWORD
 
   let get_plain_password socket =
-    get_bytes_option socket ZMQ_PLAIN_PASSWORD maximal_buffer_length
+    get_string_option socket ZMQ_PLAIN_PASSWORD maximal_buffer_length
 
   let validate_curve_key_length str msg =
     match String.length str with
@@ -457,25 +457,25 @@ module Socket = struct
     | _ -> invalid_arg msg
 
   let get_curve_publickey socket =
-    get_bytes_option socket ZMQ_CURVE_PUBLICKEY curve_z85_buffer_length
+    get_string_option socket ZMQ_CURVE_PUBLICKEY curve_z85_buffer_length
 
   let set_curve_publickey socket str =
     validate_curve_key_length str "set_curve_publickey";
-    set_bytes_option socket ZMQ_CURVE_PUBLICKEY str
+    set_string_option socket ZMQ_CURVE_PUBLICKEY str
 
   let get_curve_secretkey socket =
-    get_bytes_option socket ZMQ_CURVE_SECRETKEY curve_z85_buffer_length
+    get_string_option socket ZMQ_CURVE_SECRETKEY curve_z85_buffer_length
 
   let set_curve_secretkey socket str =
     validate_curve_key_length str "set_curve_secretkey";
-    set_bytes_option socket ZMQ_CURVE_SECRETKEY str
+    set_string_option socket ZMQ_CURVE_SECRETKEY str
 
   let get_curve_serverkey socket =
-    get_bytes_option socket ZMQ_CURVE_SERVERKEY curve_z85_buffer_length
+    get_string_option socket ZMQ_CURVE_SERVERKEY curve_z85_buffer_length
 
   let set_curve_serverkey socket str =
     validate_curve_key_length str "set_curve_serverkey";
-    set_bytes_option socket ZMQ_CURVE_SERVERKEY str
+    set_string_option socket ZMQ_CURVE_SERVERKEY str
 
   let get_mechanism socket =
     match get_int_option socket ZMQ_MECHANISM with
@@ -485,10 +485,10 @@ module Socket = struct
     | _ -> assert false
 
   let set_zap_domain socket =
-    set_bytes_option socket ZMQ_ZAP_DOMAIN
+    set_string_option socket ZMQ_ZAP_DOMAIN
 
   let get_zap_domain socket =
-    get_bytes_option socket ZMQ_ZAP_DOMAIN maximal_buffer_length
+    get_string_option socket ZMQ_ZAP_DOMAIN maximal_buffer_length
 
   let set_conflate socket flag =
     set_int_option socket ZMQ_CONFLATE (if flag then 1 else 0)

--- a/zmq/test/curve.ml
+++ b/zmq/test/curve.ml
@@ -1,0 +1,26 @@
+open OUnit
+
+(* random key generated with `curve_keygen` *)
+let z85_public = "^fh#binNS?sWfA=FHY#Rw2b{1{1kzB+Vr.kZzIAA"
+let z85_secret = "E9.KnISxjbj*R<q&Q}T69x9IvxKNwUK3q*lv5^)P"
+
+let test_set_get_key () =
+  let assert_equal = assert_equal ~printer:(fun x -> x) in
+  let ctx = Zmq.Context.create () in
+  let sock = Zmq.Socket.create ctx Zmq.Socket.pub in
+  Zmq.Socket.set_curve_publickey sock z85_public;
+  let pub = Zmq.Socket.get_curve_publickey sock in
+  assert_equal ~msg:"Matching public key" z85_public pub;
+  Zmq.Socket.set_curve_secretkey sock z85_secret;
+  let sec = Zmq.Socket.get_curve_secretkey sock in
+  assert_equal ~msg:"Matching private key" z85_secret sec;
+  Zmq.Socket.set_curve_serverkey sock z85_public;
+  let servpub = Zmq.Socket.get_curve_serverkey sock in
+  assert_equal ~msg:"Matching server key" z85_public servpub;
+
+  Zmq.Socket.close sock;
+  Zmq.Context.terminate ctx
+
+let suite = "curve" >::: [
+  "set/get key" >:: test_set_get_key
+]

--- a/zmq/test/test.ml
+++ b/zmq/test/test.ml
@@ -4,6 +4,7 @@ let suite = "Zmq" >:::
   [
     Zmq_test.suite;
     Fd_usage.suite;
+    Curve.suite;
   ]
 
 let _ =


### PR DESCRIPTION
For those, the size of the buffer passed to getsockopt is significant and must be either 32 (to receive key as binary) or 41 (to receive key as z85).

The patch merely sets the buffer size to 41 for those options, so that the caller is returned the keys in z85 format.

Previously, calling those functions would result in an error with errno set to EINVAL.

Closes #85
Closes #86

(Rebased from the previous PR #86 by @rixed which we partly merged, so we can see it build on CI)