### PR TITLE
Require JST >= 0.11 and therefore OCaml 4.04.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
     - TESTS=true
     - DISTRO=ubuntu-18.04
   matrix:
-    - OCAML_VERSION=4.03 PACKAGE="zmq"       PINS="zmq:."
-    - OCAML_VERSION=4.03 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
-    - OCAML_VERSION=4.03 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
+    - OCAML_VERSION=4.04 PACKAGE="zmq"       PINS="zmq:."
+    - OCAML_VERSION=4.04 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+    - OCAML_VERSION=4.04 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
     - OCAML_VERSION=4.08 PACKAGE="zmq"       PINS="zmq:."
     - OCAML_VERSION=4.08 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
     - OCAML_VERSION=4.08 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+* Depend on v0.11 versions of Jane Street packages to not fail on `makedev`
+  issue. This requires us to drop support for OCaml 4.03 (#93)
+
 5.1.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Dependencies
 ------------
 
   * [OPAM](http://opam.ocaml.org/)
-  * OCaml >= 4.03
-  * Async >= v0.9.0 for zmq-async
+  * OCaml >= 4.04.1
+  * Async >= v0.11.0 for zmq-async
   * Lwt for zmq-lwt
   * libzmq (c lib) >= 4.x
 

--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -12,12 +12,12 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.04.1"}
   "zmq" {= version}
   "dune"
-  "async_unix" {>= "v0.9.0" & < "v0.13"}
-  "async_kernel" {>= "v0.9.0" & < "v0.13"}
-  "base" {>= "v0.9.0" & < "v0.13"}
+  "async_unix" {>= "v0.11.0" & < "v0.13"}
+  "async_kernel" {>= "v0.11.0" & < "v0.13"}
+  "base" {>= "v0.11.0" & < "v0.13"}
   "ounit" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"

--- a/zmq-lwt.opam
+++ b/zmq-lwt.opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.04.1"}
   "zmq" {= version}
   "ounit" {with-test}
   "dune"

--- a/zmq.opam
+++ b/zmq.opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.04.1"}
   "conf-zmq"
   "dune"
   "configurator" {build & < "v0.13"}


### PR DESCRIPTION
The issue is basically described in https://github.com/ocaml/opam-repository/pull/14916#issuecomment-535503961, Core v0.9 and v0.10 does not compile on newer glibc versions, so we need to bump to v0.11 and by extension also OCaml 4.04.1 at least.