### PR TITLE
Use OPAM2 version variable for a common version for all dependencies

### DIFF
--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "zmq" {>= "5.1.0"}
+  "zmq" {= version}
   "dune"
   "async_unix" {>= "v0.9.0" & < "v0.13"}
   "async_kernel" {>= "v0.9.0" & < "v0.13"}

--- a/zmq-lwt.opam
+++ b/zmq-lwt.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "zmq" {>= "5.1.0"}
+  "zmq" {= version}
   "ounit" {with-test}
   "dune"
   "lwt"


### PR DESCRIPTION
I broke the build by making the packages depend on stuff that is unreleased in OPAM. What we actually want is a common version number across all packages and `zmq-async` and `zmq-lwt` should depend on the exact version of `zmq`.

This was suggested to me by @dbunzli.