### PR TITLE
OPAM 2 files include the descriptions, delete the old files

### DIFF
--- a/zmq-async.descr
+++ b/zmq-async.descr
@@ -1,1 +1,0 @@
-Async aware bindings to zmq

--- a/zmq-lwt.descr
+++ b/zmq-lwt.descr
@@ -1,1 +1,0 @@
-Lwt aware bindings to zmq

--- a/zmq.descr
+++ b/zmq.descr
@@ -1,7 +1,0 @@
-OCaml bindings for ZeroMQ 4.x
-
-This library contains basic bindings for zmq.
-Lwt aware bindings to zmq are availble though package zmq-lwt
-Async aware bindings to zmq are availble though package zmq-async
-
-Api documentation can be found at https://issuu.github.io/ocaml-zmq


### PR DESCRIPTION
We migrated to OPAM 2, no need for these anymore (thankfully).