### PR TITLE
Remove configurator from opam dependency list as well

### DIFF
--- a/zmq.opam
+++ b/zmq.opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "conf-zmq"
   "dune"
-  "configurator" {build & < "v0.13"}
   "ounit" {with-test}
   "base-unix"
   "stdint" {>= "0.4.2"}


### PR DESCRIPTION
We forgot this before, so the release 5.1.0 release still depends on it.