### PR TITLE
Transition to ounit2

### DIFF
--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -18,6 +18,6 @@ depends: [
   "async_unix" {>= "v0.11.0" & < "v0.13"}
   "async_kernel" {>= "v0.11.0" & < "v0.13"}
   "base" {>= "v0.11.0" & < "v0.13"}
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"

--- a/zmq-deferred/test/dune
+++ b/zmq-deferred/test/dune
@@ -1,4 +1,3 @@
 (library
  (name zmq_deferred_test)
- (wrapped true)
- (libraries zmq.deferred oUnit))
+ (libraries zmq.deferred ounit2))

--- a/zmq-lwt.opam
+++ b/zmq-lwt.opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "dune"
   "lwt"
 ]

--- a/zmq.opam
+++ b/zmq.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "conf-zmq"
   "dune"
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "base-unix"
   "stdint" {>= "0.4.2"}
 ]

--- a/zmq/test/dune
+++ b/zmq/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries oUnit zmq threads))
+ (libraries ounit2 zmq threads))
 
 (alias
  (name runtest)


### PR DESCRIPTION
ounit2 seems to be the preferred name for the future of OUnit.

On OPAM our package is already declared to not be compatible with versions above 2.1 because 2.1.x seems to be somewhat broken so we could either transition to the new names or continue to use the old names but conflict with 2.1.x. I chose the former.