### PR TITLE
Run a single build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,25 @@ env:
     - DEPOPTS="*"
     - TESTS=true
     - DISTRO=ubuntu-18.04
-  matrix:
-    - OCAML_VERSION=4.04 PACKAGE="zmq"       PINS="zmq:."
-    - OCAML_VERSION=4.04 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
-    - OCAML_VERSION=4.04 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
-    - OCAML_VERSION=4.08 PACKAGE="zmq"       PINS="zmq:."
-    - OCAML_VERSION=4.08 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
-    - OCAML_VERSION=4.08 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
-    - OCAML_VERSION=4.09 PACKAGE="zmq"       PINS="zmq:."
-    - OCAML_VERSION=4.09 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
-    - OCAML_VERSION=4.09 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
-os:
-  - linux
+matrix:
+  include:
+  - os: linux
+    env: OCAML_VERSION=4.04 PACKAGE="zmq"       PINS="zmq:."
+  - os: linux
+    env: OCAML_VERSION=4.04 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+  - os: linux
+    env: OCAML_VERSION=4.04 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
+  - os: linux
+    env: OCAML_VERSION=4.08 PACKAGE="zmq"       PINS="zmq:."
+  - os: linux
+    env: OCAML_VERSION=4.08 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+  - os: linux
+    env: OCAML_VERSION=4.08 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
+  - os: linux
+    env: OCAML_VERSION=4.09 PACKAGE="zmq"       PINS="zmq:."
+  - os: linux
+    env: OCAML_VERSION=4.09 PACKAGE="zmq-async" PINS="zmq:. zmq-async:."
+  - os: linux
+    env: OCAML_VERSION=4.09 PACKAGE="zmq-lwt"   PINS="zmq:. zmq-lwt:."
+  - os: osx
+    env: OCAML_VERSION=4.09 PACKAGE="zmq"       PINS="zmq:."


### PR DESCRIPTION
OPAM-repository runs CI builds on macOS and we sort of support it since some of us use macOS but the CI system never builds it. Unfortunately getting Travis to build on macOS is possible but takes very long to get a builder instance so we can't just build the entire matrix (even only the supported OCaml versions take a long time on Linux), so this just builds the base ZMQ package on macOS on the newest supported version.

The Travis incantation is inspired by https://github.com/mirage/alcotest/blob/master/.travis.yml, thanks to @samoht for pointing it out to me.