### PR TITLE
Fixed #100 - make 'a Socket.t covariant

### DIFF
--- a/zmq/examples/threaded_loopback.ml
+++ b/zmq/examples/threaded_loopback.ml
@@ -30,6 +30,6 @@ let () =
     Thread.create subscription subscribe_socket in
 
   List.iter Thread.join  [subscribe_thread; publish_thread];
-  List.iter Socket.close [subscribe_socket; publish_socket];
+  List.iter Socket.close [(subscribe_socket :> [`Sub | `Pub] Socket.t); (publish_socket :> [`Sub | `Pub] Socket.t)];
 
   Context.terminate context

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -85,7 +85,7 @@ end
 module Socket = struct
   open Stdint
 
-  type 'a t
+  type + 'a t
 
   (** This is an int so we know which socket we
     * are building inside the external functions *)

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -87,6 +87,7 @@ module Socket = struct
 
   type + 'a t
 
+
   (** This is an int so we know which socket we
     * are building inside the external functions *)
 
@@ -564,6 +565,24 @@ module Poll = struct
 
   type poll_event = In | Out | In_out
   type 'a poll_mask = ('a Socket.t * poll_event)
+
+  let mask_in_out t =
+    (t:>
+       [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+         Socket.t
+    ), In_out
+
+  let mask_in t =
+    (t:>
+       [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+         Socket.t
+    ), In
+
+  let mask_out t =
+    (t:>
+       [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+         Socket.t
+    ), Out
 
   external mask_of : 'a poll_mask array -> t = "caml_zmq_poll_of_pollitem_array"
   external native_poll: t -> int -> poll_event option array = "caml_zmq_poll"

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -69,21 +69,21 @@ end
 
 module Socket : sig
 
-  type 'a t
+  type + 'a t
   type 'a kind
 
-  val pair   : [>`Pair] kind
-  val pub    : [>`Pub] kind
-  val sub    : [>`Sub] kind
-  val req    : [>`Req] kind
-  val rep    : [>`Rep] kind
-  val dealer : [>`Dealer] kind
-  val router : [>`Router] kind
-  val pull   : [>`Pull] kind
-  val push   : [>`Push] kind
-  val xsub   : [>`Xsub] kind
-  val xpub   : [>`Xpub] kind
-  val stream : [>`Stream] kind
+  val pair   : [`Pair] kind
+  val pub    : [`Pub] kind
+  val sub    : [`Sub] kind
+  val req    : [`Req] kind
+  val rep    : [`Rep] kind
+  val dealer : [`Dealer] kind
+  val router : [`Router] kind
+  val pull   : [`Pull] kind
+  val push   : [`Push] kind
+  val xsub   : [`Xsub] kind
+  val xpub   : [`Xpub] kind
+  val stream : [`Stream] kind
 
   (** Creation and Destruction *)
   val create : Context.t -> 'a kind -> 'a t
@@ -155,8 +155,8 @@ module Socket : sig
   val get_affinity : 'a t -> int
   val set_identity : 'a t -> string -> unit
   val get_identity : 'a t -> string
-  val subscribe : [> `Sub] t -> string -> unit
-  val unsubscribe : [> `Sub] t -> string -> unit
+  val subscribe : [< `Sub] t -> string -> unit
+  val unsubscribe : [< `Sub] t -> string -> unit
   val get_last_endpoint : 'a t -> string
   val set_tcp_accept_filter : 'a t -> string -> unit
   val set_rate : 'a t -> int -> unit
@@ -200,10 +200,10 @@ module Socket : sig
   val get_tcp_keepalive_interval : 'a t -> [ `Default | `Value of int ]
   val set_immediate : 'a t -> bool -> unit
   val get_immediate : 'a t -> bool
-  val set_xpub_verbose : [> `XPub] t -> bool -> unit
-  val set_probe_router : [> `Router | `Dealer | `Req ] t -> bool -> unit
-  val set_req_correlate : [> `Req ] t -> bool -> unit
-  val set_req_relaxed : [> `Req ] t -> bool -> unit
+  val set_xpub_verbose : [< `XPub] t -> bool -> unit
+  val set_probe_router : [< `Router | `Dealer | `Req ] t -> bool -> unit
+  val set_req_correlate : [< `Req ] t -> bool -> unit
+  val set_req_relaxed : [< `Req ] t -> bool -> unit
   val set_plain_server : 'a t -> bool -> unit
   val set_plain_username : 'a t -> string -> unit
   val get_plain_username : 'a t -> string
@@ -219,7 +219,7 @@ module Socket : sig
   val get_mechanism : 'a t -> [`Null | `Plain | `Curve]
   val set_zap_domain : 'a t -> string -> unit
   val get_zap_domain : 'a t -> string
-  val set_conflate : [> `Pull | `Push | `Sub | `Pub | `Dealer] t -> bool -> unit
+  val set_conflate : [< `Pull | `Push | `Sub | `Pub | `Dealer] t -> bool -> unit
 
   val get_fd : 'a t -> Unix.file_descr
 
@@ -229,7 +229,7 @@ module Socket : sig
 end
 
 module Proxy : sig
-  val create: ?capture:[> `Pub|`Dealer|`Push|`Pair] Socket.t -> 'a Socket.t -> 'b Socket.t -> unit
+  val create: ?capture:[< `Pub|`Dealer|`Push|`Pair] Socket.t -> 'a Socket.t -> 'b Socket.t -> unit
 end
 
 module Poll : sig
@@ -270,12 +270,12 @@ module Monitor : sig
 
 
   val create: 'a Socket.t -> t
-  val connect: Context.t -> t -> [>`Monitor] Socket.t
+  val connect: Context.t -> t -> [<`Monitor] Socket.t
 
   (** Receive an event from the monitor socket.
       block indicates if the call should be blocking or non-blocking. Default true
   *)
-  val recv: ?block:bool -> [> `Monitor ] Socket.t -> event
+  val recv: ?block:bool -> [< `Monitor ] Socket.t -> event
 
   val string_of_event: event -> string
 

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -188,8 +188,8 @@ module Socket : sig
   val get_send_timeout : 'a t -> int
   val set_ipv6 : 'a t -> bool -> unit
   val get_ipv6 : 'a t -> bool
-  val set_router_mandatory : [`Router] t -> bool -> unit
-  val get_router_mandatory : [`Router] t -> bool
+  val set_router_mandatory : [> `Router] t -> bool -> unit
+  val get_router_mandatory : [> `Router] t -> bool
   val set_tcp_keepalive : 'a t -> [ `Default | `Value of bool ] -> unit
   val get_tcp_keepalive : 'a t -> [ `Default | `Value of bool ]
   val set_tcp_keepalive_idle : 'a t -> [ `Default | `Value of int ] -> unit

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -239,6 +239,32 @@ module Poll : sig
   type poll_event = In | Out | In_out
   type 'a poll_mask = ('a Socket.t * poll_event)
 
+
+
+  val mask_in_out :
+    [<`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    ->
+    [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    * poll_event
+
+  val mask_in :
+    [<`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    ->
+    [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    * poll_event
+
+  val mask_out :
+    [<`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    ->
+    [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
+      Socket.t
+    * poll_event
+
   val mask_of : 'a poll_mask array -> t
   val poll : ?timeout: int -> t -> poll_event option array
 

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -188,8 +188,8 @@ module Socket : sig
   val get_send_timeout : 'a t -> int
   val set_ipv6 : 'a t -> bool -> unit
   val get_ipv6 : 'a t -> bool
-  val set_router_mandatory : 'a t -> bool -> unit
-  val get_router_mandatory : 'a t -> bool
+  val set_router_mandatory : [`Router] t -> bool -> unit
+  val get_router_mandatory : [`Router] t -> bool
   val set_tcp_keepalive : 'a t -> [ `Default | `Value of bool ] -> unit
   val get_tcp_keepalive : 'a t -> [ `Default | `Value of bool ]
   val set_tcp_keepalive_idle : 'a t -> [ `Default | `Value of int ] -> unit

--- a/zmq/test/zmq_test.ml
+++ b/zmq/test/zmq_test.ml
@@ -325,7 +325,7 @@ let suite =
              bind rep endpoint;
              connect req endpoint;
              subscribe sub "";
-             let mask = mask_of [| (req :> [`Req | `Rep | `Sub] Socket.t), In_out; (rep :> [`Req | `Rep | `Sub] Socket.t), In_out; (sub :> [`Req | `Rep | `Sub] Socket.t), In_out |] in
+             let mask = mask_of [| Poll.mask_in_out req; Poll.mask_in_out rep; Poll.mask_in_out sub |] in
              assert_equal [| Some Out; None; None |] (poll ~timeout:1000 mask);
              send req "request";
              assert_equal [| None; Some In; None |] (poll ~timeout:1000 mask);

--- a/zmq/test/zmq_test.ml
+++ b/zmq/test/zmq_test.ml
@@ -325,7 +325,7 @@ let suite =
              bind rep endpoint;
              connect req endpoint;
              subscribe sub "";
-             let mask = mask_of [| req, In_out; rep, In_out; sub, In_out |] in
+             let mask = mask_of [| (req :> [`Req | `Rep | `Sub] Socket.t), In_out; (rep :> [`Req | `Rep | `Sub] Socket.t), In_out; (sub :> [`Req | `Rep | `Sub] Socket.t), In_out |] in
              assert_equal [| Some Out; None; None |] (poll ~timeout:1000 mask);
              send req "request";
              assert_equal [| None; Some In; None |] (poll ~timeout:1000 mask);


### PR DESCRIPTION
Issue was caused by the type of a socket ending up accumulating all references (by `[>`) thus by fixing the type of a socket and requiring explicit subtyping (see the tests) we get the correct type information
for a given socket.

**Summary of changes:** 
 - Make Socket.t covariant
 - Fix the type of a socket
 - Change function signatures from "must at least have" (`[>`) to "must have one of" (`[<]`)

**Potential negative effects:**
This should only affect running code which explicitly has type signatures like:
```
type t = {sock : [> `Req | `Rep] Socket.t}
```
Which would only occur if the signature type was copied from the inferred type.

**Other Notes:** 
In the test, each element of the array needs the same type, but explicitly typing each is quite clunky. For this it might be beneficial to have a function of the type:
```
val all_typed : [< `Pair | `Pub | ...] Socket.t -> [`Pair | `Pub | ...] Socket.t

let all_typed sock = (sock :> [`Pair | `Pub | ...] Socket.t)
```
This would type the array as every possible socket, but would definitely reduce the syntactic overhead.
