### PR TITLE
Fix dune-configurator missing

### DIFF
--- a/zmq.opam
+++ b/zmq.opam
@@ -18,6 +18,7 @@ depends: [
   "ounit2" {with-test}
   "base-unix"
   "stdint" {>= "0.4.2"}
+  "dune-configurator"
 ]
 conflicts: [
   "ocaml-zmq"


### PR DESCRIPTION
Previous `pull request#103` failed `travis-ci` due to `zmq` not depending on `dune-configurator`.

This PR adds that dependency.