### PR TITLE
Enable caching of OPAM folders to speed up builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 dist: bionic
+cache:
+    directories:
+    - $HOME/.opam
 env:
   global:
     - DEPOPTS="*"


### PR DESCRIPTION
Rebuilding everything from scratch is what takes a long time, so adding a cache might be potentially very helpful. I have successfully applied this to my own projects so I am hoping it might be helpful here as well.