### PR TITLE
Migrate the badge to Github workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OCaml bindings for ZMQ 4.x
 ==========================
 
-![Build Status](https://github.com/issuu/ocaml-zmq/actions/workflows/workflow.yml/badge.svg)
+[![Build Status](https://github.com/issuu/ocaml-zmq/actions/workflows/workflow.yml/badge.svg)](https://github.com/issuu/ocaml-zmq/actions/workflows/workflow.yml?query=branch%3Amaster)
 
 Dependencies
 ------------


### PR DESCRIPTION
@andersfugmann migrated the CI to Github in February, but the badge still points at Travis (which also is broken and should probably be removed).