### PR TITLE
Fix build with 4.13

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-version:
-          - 4.11.1
+          - 4.13.1
           - 4.04.1
 
     runs-on: ${{ matrix.os }}

--- a/zmq-async.opam
+++ b/zmq-async.opam
@@ -15,9 +15,9 @@ depends: [
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
   "dune"
-  "async_unix" {>= "v0.11.0" & < "v0.14"}
-  "async_kernel" {>= "v0.11.0" & < "v0.14"}
-  "base" {>= "v0.11.0" & < "v0.14"}
+  "async_unix" {>= "v0.11.0" & < "v0.15"}
+  "async_kernel" {>= "v0.11.0" & < "v0.15"}
+  "base" {>= "v0.11.0" & < "v0.15"}
   "ounit2" {with-test}
 ]
 synopsis: "Async aware bindings to zmq"

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -55,7 +55,7 @@ module Make(T: Deferred.T) = struct
           try
             f ();
             (* Success, pop the sender *)
-            Queue.pop queue |> ignore
+            (Queue.pop queue : unit -> unit) |> ignore
           with
           | Retry -> (* If f raised EAGAIN, dont pop the message *) ()
         in


### PR DESCRIPTION
The warning is because of 4.13 being smarter about the value popped from the queue being a function and thus triggers the warning that the function is not being applied. By adding a signature the compiler understands that we're aware that it is a function and ignore it deliberately.