### PR TITLE
Fix API of Zmq.Poll module

### DIFF
--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -585,6 +585,7 @@ module Poll = struct
     ), Out
 
   external mask_of : 'a poll_mask array -> t = "caml_zmq_poll_of_pollitem_array"
+  external of_mask : 'a poll_mask array -> t = "caml_zmq_poll_of_pollitem_array"
   external native_poll: t -> int -> poll_event option array = "caml_zmq_poll"
 
   let poll ?(timeout = -1) items = native_poll items timeout

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -239,15 +239,12 @@ module Poll : sig
   type poll_event = In | Out | In_out
   type 'a poll_mask = ('a Socket.t * poll_event)
 
-
-
   val mask_in_out :
     [<`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
       Socket.t
     ->
     [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
-      Socket.t
-    * poll_event
+      poll_mask
   (** @since 5.1.4 *)
 
   val mask_in :
@@ -255,8 +252,7 @@ module Poll : sig
       Socket.t
     ->
     [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
-      Socket.t
-    * poll_event
+      poll_mask
   (** @since 5.1.4 *)
 
   val mask_out :
@@ -264,8 +260,7 @@ module Poll : sig
       Socket.t
     ->
     [`Pair|`Pub|`Sub|`Req|`Rep|`Dealer|`Router|`Pull|`Push|`Xsub|`Xpub|`Stream]
-      Socket.t
-    * poll_event
+      poll_mask
   (** @since 5.1.4 *)
 
   val mask_of : 'a poll_mask array -> t [@@ocaml.alert deprecated "Please use 'Zmq.Poll.of_mask' instead"]

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -268,7 +268,8 @@ module Poll : sig
     * poll_event
   (** @since 5.1.4 *)
 
-  val mask_of : 'a poll_mask array -> t
+  val mask_of : 'a poll_mask array -> t [@@ocaml.alert deprecated "Please use 'Zmq.Poll.of_mask' instead"]
+  val of_mask : 'a poll_mask array -> t
   val poll : ?timeout: int -> t -> poll_event option array
 
 end

--- a/zmq/test/zmq_test.ml
+++ b/zmq/test/zmq_test.ml
@@ -191,7 +191,7 @@ let test_unix_exceptions = bracket
     )
     (fun (_, s) ->
 
-       let mask = Zmq.Poll.mask_of [| s, Zmq.Poll.In |] in
+       let mask = Zmq.Poll.of_mask [| s, Zmq.Poll.In |] in
        Sys.(set_signal sigalrm (Signal_handle (fun _ -> ())));
        ignore (Unix.alarm 1);
        assert_raises ~msg:"Failed to raise EINTR" Unix.(Unix_error(EINTR, "zmq_poll", ""))  (fun _ -> Zmq.Poll.poll ~timeout:2000 mask);
@@ -325,7 +325,7 @@ let suite =
              bind rep endpoint;
              connect req endpoint;
              subscribe sub "";
-             let mask = mask_of [| Poll.mask_in_out req; Poll.mask_in_out rep; Poll.mask_in_out sub |] in
+             let mask = of_mask [| Poll.mask_in_out req; Poll.mask_in_out rep; Poll.mask_in_out sub |] in
              assert_equal [| Some Out; None; None |] (poll ~timeout:1000 mask);
              send req "request";
              assert_equal [| None; Some In; None |] (poll ~timeout:1000 mask);


### PR DESCRIPTION
This PR has two separate commits, both of which fix issues with the API of the Zmq.Poll module.

The first commit is a fix for the puzzling name for `Zmq.Poll.mask_of`. Everything about this function screams that it should be named `of_mask` instead, but the puzzling name forced me to look into the implementation to see if there was some non-obvious reason why it has the counterintuitive name. I couldn't find any, and I'd rather spare other people the effort I had to go through.

Note that the commit keeps the old name, but adds a deprecation alert. Personally, I'd more inclined to ditch the old name altogether and release this as version 6.0, but some projects prefer having a deprecation alert for a release or two before forcing users to migrate.

The second commit simply changes the signatures for `Zmq.Poll.mask_in_out` et al, so that they actually use the `poll_mask` type alias. This has no implications for user code, but makes a lot more sense for the API of this module.

Anyway, if you agree with these changes I can make another commit to also update the changelog.