### PR TITLE
require stdint 0.5

### DIFF
--- a/zmq.opam
+++ b/zmq.opam
@@ -16,7 +16,7 @@ depends: [
   "conf-zmq"
   "ounit2" {with-test}
   "dune-configurator"
-  "stdint" {>= "0.4.2"}
+  "stdint" {>= "0.5"}
 ]
 conflicts: ["ocaml-zmq"]
 build: [


### PR DESCRIPTION
stdint 0.4.2 uses oasis, which uses `Stream`, now removed in OCaml 5.0