### PR TITLE
Remove dependency on StdInt

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
           - ubuntu-20.04
         ocaml-version:
           - ocaml-base-compiler.5.0.0~beta1
-          - 4.13.1
+          - 4.14.0
           - 4.04.1
 
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,25 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
+          opam-local-packages: zmq.opam
 
-      - run: opam install . --deps-only --with-doc --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+      - name: zmq
+        run: |
+          opam install --deps-only --with-doc --with-test zmq
+          opam exec -- dune build zmq
+          opam exec -- dune runtest zmq
+
+      - name: zmq-lwt
+        run: |
+          opam pin add zmq-lwt.dev . --no-action
+          opam install --deps-only --with-doc --with-test zmq-lwt
+          opam exec -- dune build zmq-lwt
+          opam exec -- dune runtest zmq-lwt
+
+      - name: zmq-async
+        if: ${{ matrix.ocaml-version != 'ocaml-base-compiler.5.0.0~beta1' }}
+        run: |
+          opam pin add zmq-async.dev . --no-action
+          opam install --deps-only --with-doc --with-test zmq-async
+          opam exec -- dune build zmq-async
+          opam exec -- dune runtest zmq-async

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-version:
+          - ocaml-base-compiler.5.0.0~beta1
           - 4.13.1
           - 4.04.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,3 @@
-5.2.0
------
 * Remove dependency on StdInt.
 
 * Silence warnings about `const char*` when writing to the inside of an

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+5.2.0
+-----
+* Remove dependency on StdInt.
+
 * Silence warnings about `const char*` when writing to the inside of an
   allocated string value (#116, @Leonidas-from-XIV)
 

--- a/dune-project
+++ b/dune-project
@@ -18,8 +18,7 @@ Async aware bindings to zmq are available though package zmq-async")
   (ocaml (>= 4.03.0))
   conf-zmq
   (ounit2 :with-test)
-  dune-configurator
-  (stdint (>= 0.4.2)))
+  dune-configurator)
  (conflicts
   ocaml-zmq))
 

--- a/zmq.opam
+++ b/zmq.opam
@@ -16,7 +16,6 @@ depends: [
   "conf-zmq"
   "ounit2" {with-test}
   "dune-configurator"
-  "stdint" {>= "0.5"}
 ]
 conflicts: ["ocaml-zmq"]
 build: [

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -170,19 +170,20 @@ CAMLprim value caml_zmq_close(value socket) {
  * Set socket options
  */
 
-static int const native_uint64_option_for[] = {
+static int const native_int64_option_for[] = {
     ZMQ_AFFINITY,
     ZMQ_MAXMSGSIZE
 };
 
-CAMLprim value caml_zmq_set_uint64_option(value socket, value option_name, value socket_option) {
+CAMLprim value caml_zmq_set_int64_option(value socket, value option_name, value socket_option) {
     CAMLparam3 (socket, option_name, socket_option);
 
     int64_t val = Long_val(socket_option);
     int result = zmq_setsockopt(CAML_ZMQ_Socket_val(socket),
-                                native_uint64_option_for[Int_val(option_name)],
+                                native_int64_option_for[Int_val(option_name)],
                                 &val,
                                 sizeof(val));
+
 
     caml_zmq_raise_if(result == -1, "zmq_setsockopt");
     CAMLreturn (Val_unit);
@@ -267,12 +268,12 @@ CAMLprim value caml_zmq_set_int_option(value socket, value option_name, value so
  * Get socket options
  */
 
-CAMLprim value caml_zmq_get_uint64_option(value socket, value option_name) {
+CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
     CAMLparam2 (socket, option_name);
-    uint64_t mark;
+    int64_t mark;
     size_t mark_size = sizeof (mark);
     int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
-                                 native_uint64_option_for[Int_val(option_name)],
+                                 native_int64_option_for[Int_val(option_name)],
                                  &mark,
                                  &mark_size);
     caml_zmq_raise_if(result == -1, "zmq_getsockopt");

--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -39,8 +39,6 @@
 #include "socket.h"
 #include "msg.h"
 
-#include <uint64.h>
-
 /**
  * Version
  */
@@ -173,32 +171,16 @@ CAMLprim value caml_zmq_close(value socket) {
  */
 
 static int const native_uint64_option_for[] = {
-    ZMQ_AFFINITY
+    ZMQ_AFFINITY,
+    ZMQ_MAXMSGSIZE
 };
 
 CAMLprim value caml_zmq_set_uint64_option(value socket, value option_name, value socket_option) {
     CAMLparam3 (socket, option_name, socket_option);
 
-    uint64_t val = Uint64_val(socket_option);
+    int64_t val = Long_val(socket_option);
     int result = zmq_setsockopt(CAML_ZMQ_Socket_val(socket),
                                 native_uint64_option_for[Int_val(option_name)],
-                                &val,
-                                sizeof(val));
-
-    caml_zmq_raise_if(result == -1, "zmq_setsockopt");
-    CAMLreturn (Val_unit);
-}
-
-static int const native_int64_option_for[] = {
-    ZMQ_MAXMSGSIZE
-};
-
-CAMLprim value caml_zmq_set_int64_option(value socket, value option_name, value socket_option) {
-    CAMLparam3 (socket, option_name, socket_option);
-
-    int64_t val = Int64_val(socket_option);
-    int result = zmq_setsockopt(CAML_ZMQ_Socket_val(socket),
-                                native_int64_option_for[Int_val(option_name)],
                                 &val,
                                 sizeof(val));
 
@@ -294,19 +276,7 @@ CAMLprim value caml_zmq_get_uint64_option(value socket, value option_name) {
                                  &mark,
                                  &mark_size);
     caml_zmq_raise_if(result == -1, "zmq_getsockopt");
-    CAMLreturn (copy_uint64(mark));
-}
-
-CAMLprim value caml_zmq_get_int64_option(value socket, value option_name) {
-    CAMLparam2 (socket, option_name);
-    int64_t mark;
-    size_t mark_size = sizeof (mark);
-    int result = zmq_getsockopt (CAML_ZMQ_Socket_val(socket),
-                                 native_int64_option_for[Int_val(option_name)],
-                                 &mark,
-                                 &mark_size);
-    caml_zmq_raise_if(result == -1, "zmq_getsockopt");
-    CAMLreturn (caml_copy_int64(mark));
+    CAMLreturn (Val_long(mark));
 }
 
 CAMLprim value caml_zmq_get_string_option(value socket, value option_name, value option_maxlen) {

--- a/zmq/src/dune
+++ b/zmq/src/dune
@@ -12,7 +12,7 @@
    -O2))
  (c_library_flags
   (:include c_library_flags.sexp))
- (libraries unix stdint bigarray))
+ (libraries unix bigarray))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp)

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -83,7 +83,6 @@ module Msg = struct
 end
 
 module Socket = struct
-  open Stdint
 
   type + 'a t
 
@@ -129,25 +128,15 @@ module Socket = struct
   external native_send_msg : 'a t -> Msg.t -> bool -> bool -> unit = "caml_zmq_send_msg"
   let send_msg ?(block = true) ?(more = false) socket message = native_send_msg socket message block more
 
-  (** Native Option Setters (private) *)
-  type int64_option =
-  | ZMQ_MAXMSGSIZE
-
-  external set_int64_option :
-    'a t -> int64_option -> int64 -> unit = "caml_zmq_set_int64_option"
-
-  external get_int64_option :
-    'a t -> int64_option -> int64 = "caml_zmq_get_int64_option"
-
-
   type uint64_option =
   | ZMQ_AFFINITY
+  | ZMQ_MAXMSGSIZE
 
   external set_uint64_option :
-    'a t -> uint64_option -> Uint64.t -> unit = "caml_zmq_set_uint64_option"
+    'a t -> uint64_option -> int -> unit = "caml_zmq_set_uint64_option"
 
   external get_uint64_option :
-    'a t -> uint64_option -> Uint64.t = "caml_zmq_get_uint64_option"
+    'a t -> uint64_option -> int = "caml_zmq_get_uint64_option"
 
 
   type string_option =
@@ -218,16 +207,16 @@ module Socket = struct
     | _ -> ()
 
   let set_max_message_size socket size =
-    set_int64_option socket ZMQ_MAXMSGSIZE (Int64.of_int size)
+    set_uint64_option socket ZMQ_MAXMSGSIZE size
 
   let get_max_message_size socket =
-    Int64.to_int (get_int64_option socket ZMQ_MAXMSGSIZE)
+    get_uint64_option socket ZMQ_MAXMSGSIZE
 
   let set_affinity socket size =
-    set_uint64_option socket ZMQ_AFFINITY (Uint64.of_int size)
+    set_uint64_option socket ZMQ_AFFINITY size
 
   let get_affinity socket =
-    Uint64.to_int (get_uint64_option socket ZMQ_AFFINITY)
+    get_uint64_option socket ZMQ_AFFINITY
 
   let set_identity socket identity =
     validate_string_length 1 255 identity "set_identity";

--- a/zmq/src/zmq.ml
+++ b/zmq/src/zmq.ml
@@ -128,15 +128,15 @@ module Socket = struct
   external native_send_msg : 'a t -> Msg.t -> bool -> bool -> unit = "caml_zmq_send_msg"
   let send_msg ?(block = true) ?(more = false) socket message = native_send_msg socket message block more
 
-  type uint64_option =
+  type int64_option =
   | ZMQ_AFFINITY
   | ZMQ_MAXMSGSIZE
 
-  external set_uint64_option :
-    'a t -> uint64_option -> int -> unit = "caml_zmq_set_uint64_option"
+  external set_int64_option :
+    'a t -> int64_option -> int -> unit = "caml_zmq_set_int64_option"
 
-  external get_uint64_option :
-    'a t -> uint64_option -> int = "caml_zmq_get_uint64_option"
+  external get_int64_option :
+    'a t -> int64_option -> int = "caml_zmq_get_int64_option"
 
 
   type string_option =
@@ -207,16 +207,16 @@ module Socket = struct
     | _ -> ()
 
   let set_max_message_size socket size =
-    set_uint64_option socket ZMQ_MAXMSGSIZE size
+    set_int64_option socket ZMQ_MAXMSGSIZE size
 
   let get_max_message_size socket =
-    get_uint64_option socket ZMQ_MAXMSGSIZE
+    get_int64_option socket ZMQ_MAXMSGSIZE
 
   let set_affinity socket size =
-    set_uint64_option socket ZMQ_AFFINITY size
+    set_int64_option socket ZMQ_AFFINITY size
 
   let get_affinity socket =
-    get_uint64_option socket ZMQ_AFFINITY
+    get_int64_option socket ZMQ_AFFINITY
 
   let set_identity socket identity =
     validate_string_length 1 255 identity "set_identity";

--- a/zmq/src/zmq.mli
+++ b/zmq/src/zmq.mli
@@ -149,10 +149,22 @@ module Socket : sig
   val send_msg_all : ?block:bool -> 'a t -> Msg.t list -> unit
 
   (** Option Getter and Setters *)
+
+  (** Set the maximum message size of a message sent in this context,
+      represented as a signed integer. A value of -1 will set the max
+      message size to 2^64-1. *)
   val set_max_message_size : 'a t -> int -> unit
+
+  (** Get the maximum message size for this context represented as a signed integer.
+      A value of -1 equals to 2^64-1. *)
   val get_max_message_size : 'a t -> int
+
+  (** Set thread affinity. Affinity is represented as a bit vector *)
   val set_affinity : 'a t -> int -> unit
+
+  (** Get thread affinity, represented as a bit vector. *)
   val get_affinity : 'a t -> int
+
   val set_identity : 'a t -> string -> unit
   val get_identity : 'a t -> string
   val subscribe : [< `Sub] t -> string -> unit

--- a/zmq/test/zmq_test.ml
+++ b/zmq/test/zmq_test.ml
@@ -69,6 +69,8 @@ let test_socket_options () =
     ()
   in
 
+  (* Verify that the default max_message_size returns is -1 *)
+  assert_equal ~msg:"Default max message size" ~printer:string_of_int (get_max_message_size socket) (-1);
 
   test_set_get_int "Highwatermark" set_receive_high_water_mark get_receive_high_water_mark socket 1235;
   test_set_get_int "Affinity" set_affinity get_affinity socket 3;

--- a/zmq/test/zmq_test.ml
+++ b/zmq/test/zmq_test.ml
@@ -72,6 +72,7 @@ let test_socket_options () =
 
   test_set_get_int "Highwatermark" set_receive_high_water_mark get_receive_high_water_mark socket 1235;
   test_set_get_int "Affinity" set_affinity get_affinity socket 3;
+  test_set_get_int "Max message size" set_max_message_size get_max_message_size socket 65537;
   test_set_get_int "Receive timeout" set_receive_timeout get_receive_timeout socket 1000;
   test_set_get_value "Tcp keepalive interval" set_tcp_keepalive_interval get_tcp_keepalive_interval socket (`Value 1000);
 


### PR DESCRIPTION
This PR removes use of `StdInt` library, and includes testing against ocaml 5.0.0 in the workflows. 
The API interface is already using standard (e.g. 63 bit) signed integers, so there is no direct change to the API.

It want to note that there is (and always have been) some strange consequences of only having 63 bit precision (or 31 bit) for that matter when calling `set_max_message_size : 'a t -> int -> unit`:

In the C stubs, integers are converted using `Long_val`:
`Long_val(0) == 0`
`Long_val(1) == 1`
`Long_val(2^62-1) == 2^62-1 (* max_int *)`

which is expected. However calling using negative values we have (due to 2's complement):
`Long_val(-1) == 2^64 -1`
`Long_val(-2^62-1) == 2^64-2^62-1` 
which means that values in the range `[2^62; 2^64-2^62-1[` cannot be expressed. (Bounds here might not be completely accurate, but the conclusion stands).

The gab will be even larger on 32 bit machine architectures. I will however argue that in practice will not be a problem. On 64 bit architectures, Users can specify messages up to `2^62-1` size with full accuracy, or use `-1` to indicate unlimited (= `2^64-1`) message size. I cannot imagine users who can argue for a case where a value in the range `[2^62; 2^64-2]` is needed in practice. 
