### PR TITLE
Fix file descriptor type to be `File` and not `Socket` for async

### DIFF
--- a/zmq-async/src/deferred.ml
+++ b/zmq-async/src/deferred.ml
@@ -35,7 +35,7 @@ module Fd = struct
   type 'a t' = 'a t
   type t = Fd.t
   let create fd =
-    Fd.create (Fd.Kind.Socket `Active) fd (Base.Info.of_string "<zmq>")
+    Fd.create Fd.Kind.File fd (Base.Info.of_string "<zmq>")
 
   let wait_readable: t -> unit t' = fun t ->
     Fd.ready_to t `Read >>= function

--- a/zmq-async/src/deferred.ml
+++ b/zmq-async/src/deferred.ml
@@ -35,6 +35,13 @@ module Fd = struct
   type 'a t' = 'a t
   type t = Fd.t
   let create fd =
+    (* The kind here seems not to matter much, but we should make sure
+       that the fd is not set into non-blocking mode, as this breaks
+       on s390x.
+       The 'File' kind avoids fd being set into non-blocking mode.
+       'Fd.create' also allows setting 'avoid_setting_nonblock', but
+       this option name is not stable across supported versions of
+       async_unix. *)
     Fd.create Fd.Kind.File fd (Base.Info.of_string "<zmq>")
 
   let wait_readable: t -> unit t' = fun t ->


### PR DESCRIPTION
This fixes a hang bug on s390x, as the file descriptor created by ZMQ is in fact a file and not a socket (verified by manual adding code to call `Fd.Kind.infer_using_stat`). 

The error was spotted on s390x release tests, where the tests would hang. Once merged I will move the tag for 5.2.0 and recreate a release. See https://github.com/ocaml/opam-repository/pull/22382



