### PR TITLE
Fix return type of caml_zmq_set_string_option

### DIFF
--- a/zmq/src/caml_zmq_stubs.c
+++ b/zmq/src/caml_zmq_stubs.c
@@ -203,7 +203,7 @@ static int const native_bytes_option_for[] = {
     ZMQ_ZAP_DOMAIN,
 };
 
-int caml_zmq_set_string_option(value socket, value option_name, value socket_option) {
+CAMLprim value caml_zmq_set_string_option(value socket, value option_name, value socket_option) {
     CAMLparam3 (socket, option_name, socket_option);
 
     const char *option_value = String_val(socket_option);


### PR DESCRIPTION
The incorrect return type causes a test failure on s390x, a big endian architecture, with OCaml 5.0.0.