### PR TITLE
Fix send_all on eio

### DIFF
--- a/zmq-eio/src/socket.ml
+++ b/zmq-eio/src/socket.ml
@@ -122,11 +122,11 @@ let send t message =
 let send_msg t message =
   request t t.senders (fun () -> Zmq.Socket.send_msg ~block:false t.socket message)
 
-let send_all t =
-  request t t.senders (fun () -> Zmq.Socket.send_all ~block:false t.socket)
+let send_all t messages =
+  request t t.senders (fun () -> Zmq.Socket.send_all ~block:false t.socket messages)
 
-let send_msg_all t =
-  request t t.senders (fun () -> Zmq.Socket.send_msg_all ~block:false t.socket)
+let send_msg_all t messages =
+  request t t.senders (fun () -> Zmq.Socket.send_msg_all ~block:false t.socket messages)
 
 let recv t =
   request t t.receivers (fun () -> Zmq.Socket.recv ~block:false t.socket)

--- a/zmq-eio/src/socket.ml
+++ b/zmq-eio/src/socket.ml
@@ -123,10 +123,10 @@ let send_msg t message =
   request t t.senders (fun () -> Zmq.Socket.send_msg ~block:false t.socket message)
 
 let send_all t =
-  request t t.receivers (fun () -> Zmq.Socket.send_all ~block:false t.socket)
+  request t t.senders (fun () -> Zmq.Socket.send_all ~block:false t.socket)
 
 let send_msg_all t =
-  request t t.receivers (fun () -> Zmq.Socket.send_msg_all ~block:false t.socket)
+  request t t.senders (fun () -> Zmq.Socket.send_msg_all ~block:false t.socket)
 
 let recv t =
   request t t.receivers (fun () -> Zmq.Socket.recv ~block:false t.socket)

--- a/zmq-eio/test/test.ml
+++ b/zmq-eio/test/test.ml
@@ -38,11 +38,31 @@ let send env ?(delay = 0.0) s count =
   in
   fun () -> inner count
 
+let send_all env ?(delay = 0.0) s count =
+  let rec inner = function
+    | 0 -> ()
+    | n ->
+      Zmq_eio.Socket.send_all s ["test1"; "test2"; "test3"];
+      sleepf env delay;
+      inner (n - 1)
+  in
+  fun () -> inner count
+
 let recv env ?(delay = 0.0) s count =
   let rec inner = function
     | 0 -> ()
     | n ->
       let _ = Zmq_eio.Socket.recv s in
+      sleepf env delay;
+      inner (n - 1)
+  in
+  fun () -> inner count
+
+let recv_all env ?(delay = 0.0) s count =
+  let rec inner = function
+    | 0 -> ()
+    | n ->
+      let _ = Zmq_eio.Socket.recv_all s in
       sleepf env delay;
       inner (n - 1)
   in
@@ -57,6 +77,12 @@ let test_send_receive ~sw:_ env (_, s1, s2) =
   all_ok [
     send env s2 count;
     recv env s1 count;
+  ]
+
+let test_send_receive_all ~sw:_ env (_, s1, s2) =
+  all_ok [
+    send_all env s2 count;
+    recv_all env s1 count;
   ]
 
 let test_msend_mreceive ~sw:_ env (_, s1, s2) =
@@ -124,15 +150,15 @@ let suite () =
   in
 
   __MODULE__ >::: [
-    "test_setup_teardown" >:: bracket test_setup_teardown;
-    "test_send_receive"   >:: bracket test_send_receive;
-    "test_msend_mreceive" >:: bracket test_msend_mreceive;
-    "test_mix"            >:: bracket test_mix;
-    "test_slow_send"      >:: bracket test_slow_send;
-    "test_slow_receive"   >:: bracket test_slow_receive;
-    "test_slow_mix"       >:: bracket test_slow_mix1;
-    "test_slow_mix"       >:: bracket test_slow_mix2;
-    "test_send_receive"   >:: bracket test_send_receive;
+    "test_setup_teardown"   >:: bracket test_setup_teardown;
+    "test_send_receive"     >:: bracket test_send_receive;
+    "test_msend_mreceive"   >:: bracket test_msend_mreceive;
+    "test_mix"              >:: bracket test_mix;
+    "test_slow_send"        >:: bracket test_slow_send;
+    "test_slow_receive"     >:: bracket test_slow_receive;
+    "test_slow_mix"         >:: bracket test_slow_mix1;
+    "test_slow_mix"         >:: bracket test_slow_mix2;
+    "test_send_receive_all" >:: bracket test_send_receive_all;
   ]
 
 


### PR DESCRIPTION
Was trying the bindings on eio and for some reason `Zmq_eio.Socket.send_all` wasn't working at all, but `Zmq_eio.Socket.send` was. Checked the source code and I suppose the wrong argument was given inside the function (do correct me if I'm wrong).
It finally works with the change locally built on my machine (at least I think so).