### PR TITLE
WIP: Fix that `EINTR` should be ignored on `zmq_recv` or propagated to corresponding caller

### DIFF
--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -141,11 +141,8 @@ module Make(T: Deferred.T) = struct
           event_loop t
         | exception Unix.Unix_error(Unix.ENOTSOCK, "zmq_getsockopt", "") ->
           Deferred.return ()
-        | exception Unix.Unix_error(Unix.EINTR, (
-            "zmq_msg_recv"
-          | "zmq_getsockopt"
-        ), "") ->
-          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR, retrying..\n%!";
+        | exception Unix.Unix_error(Unix.EINTR, "zmq_getsockopt", "") ->
+          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR in event-loop - retrying..\n%!";
           event_loop t
       end
 
@@ -169,7 +166,9 @@ module Make(T: Deferred.T) = struct
     let f' mailbox () =
       let res = match f t.socket with
         | v -> Ok v
-        | exception Unix.Unix_error (Unix.EAGAIN, _, _) ->
+        | exception Unix.Unix_error (Unix.EAGAIN, _, _) 
+        | exception Unix.Unix_error (Unix.EINTR, "zmq_msg_recv", _) ->
+          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR from 'zmq_msg_recv' - retrying..\n%!";
           (* Signal try again *)
           raise Retry
         | exception exn -> Error exn

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -141,7 +141,11 @@ module Make(T: Deferred.T) = struct
           event_loop t
         | exception Unix.Unix_error(Unix.ENOTSOCK, "zmq_getsockopt", "") ->
           Deferred.return ()
-        | exception Unix.Unix_error(Unix.EINTR, "zmq_getsockopt", "") ->
+        | exception Unix.Unix_error(Unix.EINTR, (
+            "zmq_msg_recv"
+          | "zmq_getsockopt"
+        ), "") ->
+          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR, retrying..\n%!";
           event_loop t
       end
 

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -166,10 +166,11 @@ module Make(T: Deferred.T) = struct
     let f' mailbox () =
       let res = match f t.socket with
         | v -> Ok v
-        | exception Unix.Unix_error (Unix.EAGAIN, _, _) 
+        | exception Unix.Unix_error (Unix.EAGAIN, _, _) -> 
+          (* Signal try again *)
+          raise Retry
         | exception Unix.Unix_error (Unix.EINTR, "zmq_msg_recv", _) ->
           Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR from 'zmq_msg_recv' - retrying..\n%!";
-          (* Signal try again *)
           raise Retry
         | exception exn -> Error exn
       in

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -141,6 +141,9 @@ module Make(T: Deferred.T) = struct
           event_loop t
         | exception Unix.Unix_error(Unix.ENOTSOCK, "zmq_getsockopt", "") ->
           Deferred.return ()
+        | exception Unix.Unix_error(Unix.EINTR, "zmq_getsockopt", "") ->
+          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR, retrying..\n%!";
+          event_loop t
       end
 
   let of_socket: ('a Zmq.Socket.t -> 'a t) of_socket_args = fun socket ->

--- a/zmq-deferred/src/socket.ml
+++ b/zmq-deferred/src/socket.ml
@@ -142,7 +142,6 @@ module Make(T: Deferred.T) = struct
         | exception Unix.Unix_error(Unix.ENOTSOCK, "zmq_getsockopt", "") ->
           Deferred.return ()
         | exception Unix.Unix_error(Unix.EINTR, "zmq_getsockopt", "") ->
-          Format.eprintf "DEBUG: ZMQ-lwt: Got EINTR, retrying..\n%!";
           event_loop t
       end
 


### PR DESCRIPTION
This works for when getting `EINTR` on `zmq_recv`. 

I guess that we would want to *only* ignore this error on this specific call, but that information is not present in the code at that point. A solution could be to somehow propagate the `EINTR` to the user thread that lead to the error. The user then knows that the last call e.g. was a `recv` and can ignore the error. 

From reading the code in `zmq-deferred/src/socket.ml` - I'm currently unsure of how this could be done in the best way. I'm thinking that the corresponding callback in `t.receivers` should be woken up with the `EINTR` exception - so either communicate this exception via a new field in `t` or change the interface of all `receivers` to take an `exn option` as argument. To make the semantics consistent - all `senders` should also get this error propagated.

But how to know what `receiver`/`sender` that caused `EINTR`... 

------------------------

## Update after testing

As retrying `recv` on `EINTR` works as implemented now, without giving the error to the user - the question is if we ever want to propagate `EINTR` instead of auto-retrying. This would demand a more complex solution, as discussed earlier. 

Personally I currently think that it doesn't make much sense to propagate `EINTR`. I havn't tried a case where e.g. Ctrl-c didn't work on the process using ZMQ, so that signal is propagated fine. I don't know how we would even know what signal lead to `EINTR` - which is pretty essential for the user if they need to act upon it... 

Also, currently `ocaml-zmq` already retries reading from socket in certain cases.

Therefore I think this simple fix seems like the right one.

As an aside: Maybe some users would be interested in knowing if `EINTR` / retry has happened (I for one would be interested) - so maybe a user-setable 'logger' could be added to `Deferred.T`. 

------------------------

## Todo before merge
* [ ] make a decision on if this auto-retry method is the best way to go, or if user instead should get the `EINTR` error propagated to the `recv` caller
* [ ] make a decision on if there should be added a way to log internal retries to user (I'd be interested in this). Should be its own PR.
* [ ] make a decision on what to do about possibility of broken messages from `recv_all` after retrying following `EINTR`
  * documentation should be updated on this
  * or we could try to do some internal validation of messages / drop next message after `EINTR` happening on `'zmq_msg_recv'`